### PR TITLE
Single check - Children added success page

### DIFF
--- a/app/views/current/parent-soft-check/check-answers.html
+++ b/app/views/current/parent-soft-check/check-answers.html
@@ -160,13 +160,14 @@
       <input type="hidden" name="answers-checked" value="true">
 
 
-      <button class="govuk-button govuk-!-margin-top-5" data-module="govuk-button">
-       Register details
-      </button>
-
-
     </form>
 
+    {% from "govuk/components/button/macro.njk" import govukButton %}
+
+{{ govukButton({
+  text: "Register details",
+  href: '../parent-soft-check/children-added'
+}) }}
   
 
   </div>

--- a/app/views/current/parent-soft-check/children-added.html
+++ b/app/views/current/parent-soft-check/children-added.html
@@ -1,0 +1,41 @@
+{% extends "../../current/checker/layouts/layout-dfe.html" %}
+
+{% set pageName="Outcome not entitled" %}
+
+
+
+{% block content %}
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <span class="govuk-caption-l">Reference 44455453</span>
+        <h1 class="govuk-heading-xl">Children added</h1>
+        <p>We have sent your details to Bramhope Primary School.</p>
+    </div>
+  </div>
+</div>
+
+<h2 class="govuk-heading-m">What happens next</h2>
+
+
+      <p>  The school will email you when they have registered your details, and will arrange for your children's free school meals to start. </p>
+
+<p>If you do not receive an update in 5 working days talk to the school administrator.</p>
+
+
+<p><a href="">Sign out</a></p>
+
+
+
+
+
+
+  </div>
+</div>
+
+{% endblock %}
+
+{% block pageScripts %}
+<script type="text/javascript" src="/public/javascripts/moj/all.js"></script>
+{% endblock %}


### PR DESCRIPTION
Context
We need to add a new Children added success page to the happy path. This page will be hit from the "[Check your answers](https://check-your-eligibility-prototype.azurewebsites.net/current/parent-soft-check/check-answers)". 

The new success page will be similar to the unhappy path one about appeals:
https://check-your-eligibility-prototype.azurewebsites.net/current/checker/application-sent-to-la



Use case:
1) Parent does a check
2) Soft check outcome is Entitled
3) Parent adds children details
4) Parent lands on a "Children added" success page