### PR TITLE
Multiple changes to tickets based on PO signoff

### DIFF
--- a/app/views/current/account/DSI-landingpage.html
+++ b/app/views/current/account/DSI-landingpage.html
@@ -56,18 +56,18 @@
           ],
           [
             {
-              html: '<a href="../checker-la/dashboard.html">ECS - Local Authority</a>'
+              html: '<a href="../checker-la/dashboard.html">FSM Eligibility checking - Local Authority</a>'
             },
             {
-              text: "ECS - Local Authority"
+              text: "FSM Eligibility checking - Local Authority"
             }
           ],
           [
             {
-              html: '<a href="../checker/dashboard">ECS - Schools</a>'
+              html: '<a href="../checker/dashboard">FSM Eligibility checking - Schools</a>'
             },
             {
-              text: "ECS - Schools"
+              text: "FSM Eligibility checking - Schools"
             }
           ]
         ]

--- a/app/views/current/account/start-now.html
+++ b/app/views/current/account/start-now.html
@@ -32,7 +32,7 @@
 
   <ul class="govuk-list--bullet">
     <li>provide a National Insurance number or asylum support reference number (previously NASS reference number)</li>
-    <li>create or sign in to a OneGov account</li>
+    <li>create or sign in to a GOV.UK One Login account</li>
     <li>tell us details about any children you want to get free school meals, including the name of their school</li>
 </ul>
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/app/views/current/parent-soft-check/check.html
+++ b/app/views/current/parent-soft-check/check.html
@@ -16,11 +16,12 @@
       <div class="govuk-grid-column-two-thirds">
 
         <h1 class="govuk-heading-l">Enter your details</h1>
+        <p>The information you provide will be compared with other government departments records to check for your eligibility. For further information, please check our <a href=""> privacy statement</a>.</p>
 
     <form action="/soft-check-ni-answer" method="post" novalidate>
 
  
-
+      {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 
 

--- a/app/views/current/parent-soft-check/children-added.html
+++ b/app/views/current/parent-soft-check/children-added.html
@@ -47,7 +47,7 @@
 
   <p>
     For any queries about the application, please write the reference numbers
-    down.
+    down and discuss with your school administrator.
   </p>
 
   <h2 class="govuk-heading-m">What happens next</h2>
@@ -57,7 +57,7 @@
     their systems, and will arrange for your children’s free school meals to
     start.
   </p>
-  <p>If you do not receive an update soon, talk to the school administrator.</p>
+  <p>If you do not receive an update, talk to the school administrator.</p>
 
   <p>
     <a href="">What did you think about this service?</a> (takes 30 seconds)

--- a/app/views/current/parent-soft-check/eligible.html
+++ b/app/views/current/parent-soft-check/eligible.html
@@ -12,17 +12,22 @@
     <p>To get free school meals for your children, follow these steps online. This typically takes just a few minutes.</p>
       
     <ol>
-      <li>Create or sign into your OneGov account.</li>
+      <li>Create or sign into your GOV.UK One Login account.</li>
       <li>Enter the details of your children and their school.</li>
       <li>These will be sent on to the school, which will arrange free school meals.</li>
       </ol>
 
+      {% from "govuk/components/details/macro.njk" import govukDetails %}
 
+      {{ govukDetails({
+        summaryText: "About GOV.UK One Login",
+        text: "GOV.UK One Login lets you sign in and prove your identity quickly and easily. You can use the same account for some other government services."
+      }) }}
 
 
 <form action="account/signin-or-create" method="post" novalidate>
   <button class="govuk-button govuk-!-margin-top-5" data-module="govuk-button">
-    Go to OneGov
+    Continue to GOV.UK One Login
     </button>
 </form>
 </div>

--- a/app/views/current/parent-soft-check/start-now.html
+++ b/app/views/current/parent-soft-check/start-now.html
@@ -91,7 +91,7 @@
 
 
 <ul class="govuk-list govuk-list--bullet">
-    <li>To create or sign in to a <a target="_blank" href="https://signin.account.gov.uk/sign-in-or-create">OneGov account</a></li>
+    <li>To create or sign in to a <a target="_blank" href="https://signin.account.gov.uk/sign-in-or-create">GOV.UK One Login account</a></li>
     <li>a  National Insurance number - if you do not have one, you can apply for a National Insurance number </li>
     <li> to tell us details about any children you want to get free school meals for, including the name of their school </li>
 


### PR DESCRIPTION
Changes can be found in the PO signoff lucid board:

- I've added 'FSM Eligibility checking [title]' to the DSI-landing page
- Changed OneGov on the front page [GOV.UK](http://gov.uk/) One Login
- Added the privacy statement comment on the enter your parent details page (but link doesn't go to anywhere as we don't have the privacy statement yet.
- I've added the 'Some other government services' change to the entitled page. Haven't made the change to line three yet.
- Made the slight changes to the complete page too.