### PR TITLE
Temporary re-route for govuk sign in

### DIFF
--- a/app/routes/mvp3/appeal.js
+++ b/app/routes/mvp3/appeal.js
@@ -18,7 +18,12 @@ module.exports = function (router) {
   })
   ///////////////////////////////////////////////////////////////////////////////////////
 
-  //////GOV login variable///////
+  ///temp gov routes///
+  router.post('/mvp3-gov', function (req, res) {
+    res.redirect('/mvp3/_family/account/appeal/evidence/have-evidence.html');
+})
+
+  //////GOV login either or routng - needs fixing///////
 // module.exports = function (router) {
 
   router.get('/mvp3/_family/parent-soft-check/outcomes/outcome-not-entitled-appeal', (req, res) => {

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -450,7 +450,7 @@
                   <td class="govuk-table__cell">date</td>
                   <td class="govuk-table__cell">#</td>
                   <td class="govuk-table__cell">#XX</td>
-                  <td class="govuk-table__cell"><span class="govuk-tag govuk-tag--grey">Not started</span>
+                  <td class="govuk-table__cell"><span class="govuk-tag govuk-tag--blue">WIP</span>
                   <td class="govuk-table__cell">New: Gives info on what will come with next step <br> Also same page
                     that will show summary</td>
                 </tr>
@@ -459,8 +459,8 @@
                   <td class="govuk-table__cell"> <a href="mvp3/_family/account/appeal/add-child/child-details-1 " class="govuk-link ">Appeal page 8 - Child details</a>
                   <td class="govuk-table__cell">date</td>
                   <td class="govuk-table__cell">#</td>
-                  <td class="govuk-table__cell">#XX</td>
-                  <td class="govuk-table__cell"><span class="govuk-tag govuk-tag--grey">Not started</span>
+                  <td class="govuk-table__cell">#240</td>
+                  <td class="govuk-table__cell"><span class="govuk-tag govuk-tag--blue">WIP</span>
                   <td class="govuk-table__cell">New: DWP flow page 1</td>
                 </tr>
                 <!---row 4--->
@@ -469,8 +469,8 @@
                       lookup</a>
                   <td class="govuk-table__cell">date</td>
                   <td class="govuk-table__cell">#</td>
-                  <td class="govuk-table__cell">#XX</td>
-                  <td class="govuk-table__cell"><span class="govuk-tag govuk-tag--grey">Not started</span>
+                  <td class="govuk-table__cell">#240</td>
+                  <td class="govuk-table__cell"><span class="govuk-tag govuk-tag--blue">WIP</span>
                   <td class="govuk-table__cell">New: DWP flow page 2</td>
                 </tr>
               </tbody>

--- a/app/views/mvp3/_family/account/appeal/signin/check-your-phone.html
+++ b/app/views/mvp3/_family/account/appeal/signin/check-your-phone.html
@@ -8,7 +8,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds ">
+
     <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">Check your phone</h1>
+
     <div class="govuk-inset-text">
       We have sent a code to *******6975.
     </div>
@@ -16,12 +18,12 @@
     <p class="govuk-body">It might take a few minutes to arrive. The code will expire after 15 minutes.</p>
 
     {% if data['parent-portal'] == 'evidence-required' %}
-    <!---
+<!---
     <form action="../checker-parent/dashboard?=la" method="post">
     -->
-    {% else %}
+      {% else %}
 
-    <form action="../account/apply/childs-age" method="post">
+    <form action="/mvp3-gov" method="post">
 
       {% endif %}
       <div class="govuk-form-group">
@@ -37,7 +39,7 @@
       <button type="Submit" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button">
         Continue
       </button>
-
+</form>
 
       <details class="govuk-details" data-module="govuk-details">
         <summary class="govuk-details__summary">

--- a/app/views/mvp3/_family/account/appeal/signin/enter-password.html
+++ b/app/views/mvp3/_family/account/appeal/signin/enter-password.html
@@ -1,0 +1,72 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Enter your password" %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds ">
+
+    <form action="check-your-phone" id="form-tracking" method="post" novalidate="">
+
+      <div class="govuk-show-password" data-module="show-password" data-disable-form-submit-check="false"
+        data-show-text="Show" data-hide-text="Hide" data-show-full-text="Show password"
+        data-hide-full-text="Hide password" data-announce-show="Your password is shown"
+        data-announce-hide="Your password is hidden">
+
+
+        <div class="govuk-form-group">
+          <h1 class="govuk-label-wrapper">
+            <label class="govuk-label govuk-label--l" for="password">
+              {{pageName}}
+            </label>
+          </h1>
+          <div class="govuk-show-password__input-wrapper"><input
+              class="govuk-input govuk-!-width-two-thirds govuk-password-input govuk-input--with-password" id="password"
+              name="password" type="password" spellcheck="false" autocomplete="off"><button
+              class="govuk-button govuk-button--secondary govuk-show-password__toggle" aria-controls="password"
+              type="button" aria-label="Show password">Show</button><span class="govuk-visually-hidden"
+              aria-live="polite">Your password is hidden</span></div>
+
+        </div>
+      </div>
+    
+
+
+      <button type="Submit" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button">
+        Continue
+      </button>
+
+
+      <p class="govuk-body">
+        <a href="/account/password/reset" class="govuk-link" rel="noreferrer noopener">I’ve forgotten my password</a>
+      </p>
+
+    </form>
+<!---
+  <form action="govuk-show-password" method="post" novalidate>
+   {{ govukInput({
+    id: "[apply][password]",
+    name: "[apply][password]",
+    label: {
+      text: pageName,
+      isPageHeading: true,
+      classes: "govuk-label--l"
+    },
+    type: "password",
+    spellcheck: "false",
+    autocomplete: "off",
+    value: data.apply.password
+   }) }}
+   {{govuk-show-password}}
+  </form>
+-->
+
+
+
+  </div>
+</div>
+
+
+
+{% endblock %}

--- a/app/views/mvp3/_family/account/appeal/signin/login.html
+++ b/app/views/mvp3/_family/account/appeal/signin/login.html
@@ -1,0 +1,36 @@
+{% extends "layouts/layout-dfe.html" %}
+
+{% set pageName="Home" %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+
+    <span class="govuk-hint">Jonathan Spencer</span>
+    <h1 class="govuk-heading-l">
+      
+      
+      Eligibility checker hub
+    </h1>
+
+
+    <div class="govuk-grid-row">
+
+            
+      <div class="govuk-grid-column-full">
+        
+
+
+
+        
+      </div>  
+    
+    </div>
+
+  
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/mvp3/_family/account/appeal/signin/onegov-signin.html
+++ b/app/views/mvp3/_family/account/appeal/signin/onegov-signin.html
@@ -1,0 +1,50 @@
+{% extends "layouts/mvp1.html" %}
+
+{% set pageName="Enter your email address" %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds ">
+
+    <input type="hidden" name="_csrf" value="NwbSEw2n-Gna8N8BwZSNt77jGcnGYDP8tfjs">
+    <form action="enter-password" method="post" novalidate>
+
+      <div class="govuk-form-group">
+        <h1 class="govuk-label-wrapper">
+          <label class="govuk-label govuk-label--l" for="email">
+            Enter your email address to sign in to your GOV.UK One Login
+          </label>
+        </h1>
+
+        <input class="govuk-input govuk-input--width" id="email" name="email" type="email" spellcheck="false" autocomplete="email">
+
+      </div>
+
+      <!--
+{{ govukInput({
+  id: "[account][email]",
+  name: "[account][email]",
+  label: {
+    text: "Enter your email address to sign in to your GOV.UK One Login
+    ",
+    isPageHeading: true,
+    classes: "govuk-label--l"
+  },
+  value: data.account.email
+}) }}
+-->
+      {{ govukButton({
+      text: "Continue",
+      classes:'govuk-!-margin-top-5'
+      }) }}
+    </form>
+
+
+
+
+  </div>
+</div>
+
+
+
+{% endblock %}

--- a/app/views/mvp3/_family/account/appeal/signin/signin-or-create.html
+++ b/app/views/mvp3/_family/account/appeal/signin/signin-or-create.html
@@ -1,0 +1,80 @@
+{% extends "layouts/mvp1.html" %}
+
+{% set pageName="Sign in or create a GovUK One Login account" %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds ">
+      
+
+
+<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">Create a GOV.UK One Login or sign in</h1>
+
+
+<p class="govuk-body">You’ll need:</p>
+<ul class="govuk-list govuk-list--bullet">
+<li>an email address</li>
+
+<li>a way to get security codes - this can be a mobile phone number or an authenticator app</li>
+
+</ul>
+
+
+<div class="govuk-inset-text">
+
+You can also 
+<a href="?lng=cy" class="govuk-link" rel="noreferrer">
+use GOV.UK One Login in Welsh
+<span lang="cy">(Cymraeg)</span></a>.
+
+</div>
+
+
+<form action="/onegov-signin" method="post" novalidate>
+
+    {{ govukButton({
+        text: "Create a GOV.UK One Login",
+        href: "#",
+        classes: "govuk-button govuk-!-margin-right-3"    
+      }) }}
+    
+    {{ govukButton({
+      text: "Sign in",
+      href: "onegov-signin",
+      classes: "govuk-button--secondary"
+    
+    }) }}
+   <!-- <p><a href="../checker-parent/name">Continue without creating an account</a></p>-->
+</form>
+
+
+
+
+
+
+
+
+
+
+<details class="govuk-details" data-module="govuk-details">
+<summary class="govuk-details__summary">
+<span class="govuk-details__summary-text">
+About GOV.UK One Login
+</span>
+</summary>
+<div class="govuk-details__text">
+
+<p class="govuk-body">GOV.UK One Login is new. At the moment you can only use it to access some government services.</p>
+<p class="govuk-body">It does not work with all government accounts or services yet (for example Government Gateway or Universal Credit).</p>
+<p class="govuk-body">In the future, you’ll be able to use GOV.UK One Login to access all services on GOV.UK.</p>
+
+</div>
+</details>
+
+
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/mvp3/_family/parent-soft-check/outcomes/outcome-not-entitled-appeal.html
+++ b/app/views/mvp3/_family/parent-soft-check/outcomes/outcome-not-entitled-appeal.html
@@ -56,7 +56,7 @@
             </details>
 
             <p><a href="/mvp3/_family/guidance/parent-guidance#:~:text=Providing%20the%20right%20evidence"
-                  class="govuk-link">More information on supporting evidence</a>.</p>
+                        class="govuk-link">More information on supporting evidence</a>.</p>
 
             <h2 class="govuk-heading-m">If you have evidence now</h2>
             <p>You can appeal online and upload your evidence now.</p>
@@ -64,26 +64,27 @@
             <h2 class="govuk-heading-m">If you need time to find more evidence</h2>
             <p class="govuk-body">You can appeal:</p>
 
-                  <ul class="govuk-list govuk-list--bullet">
-                        <li>online now and choose to take your evidence into your children's schools later</li>
-                        <li>in full later through your children's schools</li>
-                  </ul>
+            <ul class="govuk-list govuk-list--bullet">
+                  <li>online now and choose to take your evidence into your children's schools later</li>
+                  <li>in full later through your children's schools</li>
+            </ul>
 
             <div class="govuk-warning-text">
                   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
                   <strong class="govuk-warning-text__text">
-                    <span class="govuk-visually-hidden">Warning</span>
-                    If want to appeal online, you need to do this now or you will need to apply again later
+                        <span class="govuk-visually-hidden">Warning</span>
+                        If want to appeal online, you need to do this now or you will need to apply again later
                   </strong>
-                </div>
+            </div>
 
 
             <div class="govuk-button-group">
                   {{ govukButton({
                   text: "Appeal now",
-                  href: "../../account/signin-or-create"
+                  href: "../../account/appeal/signin/signin-or-create"
                   }) }}
-                  <a class="govuk-link" href="../../../_offline/fsm-print-version.html">Appeal through your children's schools</a>
+                  <a class="govuk-link" href="../../../_offline/fsm-print-version.html">Appeal through your children's
+                        schools</a>
             </div>
             <!--Need to look at this content-->
 


### PR DESCRIPTION
Route not working for using incoming page as starting data point so needs fixing when I get back

This is a temp fix but means theres an additional folder with dupe screens for gov login.

folder for additional screens is /account/appeal/signin

