### PR TITLE
Add FSM translations and update eligibility UI

### DIFF
--- a/app/data/translations/fsm.js
+++ b/app/data/translations/fsm.js
@@ -1,0 +1,36 @@
+module.exports = {
+  checkerPage: {
+    en: {
+      pageName: "Run a check for one parent or guardian",
+      intro: "Enter the details of the parent or guardian who applied for free school meals.",
+      firstName: "First name",
+      lastName: "Last name",
+      dateOfBirth: "Date of birth",
+      exampleDob: "For example, 31 3 1980",
+      day: "Day",
+      month: "Month",
+      year: "Year",
+      niNumber: "National Insurance number",
+      exampleNi: "For example, QQ123456C",
+      asylumLink: "Parent or guardian is an asylum seeker",
+      button: "Run check",
+      back: "Back"
+    },
+    cy: {
+      pageName: "Rhedeg gwiriad ar gyfer un rhiant neu warcheidwad",
+      intro: "Rhowch fanylion y rhiant neu’r gwarcheidwad sydd wedi gwneud cais am brydau ysgol am ddim.",
+      firstName: "Enw cyntaf",
+      lastName: "Cyfenw",
+      dateOfBirth: "Dyddiad geni",
+      exampleDob: "Er enghraifft, 31 3 1980",
+      day: "Diwrnod",
+      month: "Mis",
+      year: "Blwyddyn",
+      niNumber: "Rhif Yswiriant Gwladol",
+      exampleNi: "Er enghraifft, QQ123456C",
+      asylumLink: "Mae’r rhiant neu’r gwarcheidwad yn geisiwr lloches",
+      button: "Rhedeg gwiriad",
+      back: "Yn ôl"
+    }
+  }
+}

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/la-soft-check/outcomes/eligible-targeted.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/la-soft-check/outcomes/eligible-targeted.html
@@ -11,6 +11,7 @@
   {% set pageName = "Children eligible for expanded free school meals" %}
   {% set outcomeTitle = "Children eligible for free school meals" %}
   {% set outcomeMessage = "are eligible for free school meals only." %}
+  {% set endDate = "2027-08-31" %}
   {% set policyLabel = "FSM Expanded" %}
 {% endif %}
 
@@ -51,6 +52,8 @@
       </div>
 
     </div>
+
+
 
     <p>This information should be passed on to their school.</p>
 

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/report/search.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/report/search.html
@@ -55,6 +55,7 @@
                           <th scope="col" class="govuk-table__header" aria-sort="none">Child dob</th>
                           <th scope="col" class="govuk-table__header" aria-sort="none">School</th>
                           <th scope="col" class="govuk-table__header" aria-sort="none">Date submitted</th>
+                          <th scope="col" class="govuk-table__header" aria-sort="none">End date</th>
                           <th scope="col" class="govuk-table__header" aria-sort="none">Status</th>
                           <!-- <th scope="col" class="govuk-table__header" aria-sort="none">Action</th>  -->
                         </tr>
@@ -138,8 +139,8 @@ document.addEventListener('DOMContentLoaded', () => {
     'status-eligible-targeted': 'FSM eligible targeted',
     'status-not-eligible': 'Not eligible',
     'status-evidence-needed': 'Evidence needed',
-    'status-in-review': 'In review',
-    'status-finalised': 'Finalised',
+    'status-in-review': 'Application in review',
+    'status-finalised': 'Completed targeted',
     'status-archived': 'Archived'
   };
 

--- a/app/views/FSM/Private_beta/v8-1/LA_Basic/basic-manage/basic-soft-check/outcomes/eligible-expanded.html
+++ b/app/views/FSM/Private_beta/v8-1/LA_Basic/basic-manage/basic-soft-check/outcomes/eligible-expanded.html
@@ -35,7 +35,7 @@
           The children of {{ data["parent-firstname"] or "Derrick" }} {{ data["parent-surname"] or "Stark" }} {{ outcomeMessage }}
         </h3>
 
-       <p class="govuk-body">
+       <!-- <p class="govuk-body">
   <strong>Support level:</strong>
 
   <strong class="govuk-tag
@@ -47,10 +47,42 @@
   ">
     {{ policyLabel }}
   </strong>
-</p>
+</p> -->
       </div>
 
     </div>
+
+
+
+    <h2 class="govuk-heading-m">Eligibility details</h2>
+
+<dl class="govuk-summary-list">
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Status</dt>
+    <dd class="govuk-summary-list__value">
+      <strong class="govuk-tag
+        {% if eligibilityType == 'targeted' %}
+          govuk-tag--purple
+        {% else %}
+          govuk-tag--green
+        {% endif %}
+      ">
+        {% if eligibilityType == "expanded" %}
+          Eligible targeted
+        {% else %}
+          Eligible expanded
+        {% endif %}
+      </strong>
+    </dd>
+  </div>
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Eligibility end date</dt>
+    <dd class="govuk-summary-list__value">31 March 2026</dd>
+  </div>
+
+</dl>
 
     <p>This information should be passed on to their school.</p>
   <p>You can <a href="" class="govuk-link" onclick="printPage()">print this page</a> for the parent or guardian to keep.</p>

--- a/app/views/FSM/Private_beta/v8-1/LA_Basic/basic-manage/basic-soft-check/outcomes/eligible-targeted.html
+++ b/app/views/FSM/Private_beta/v8-1/LA_Basic/basic-manage/basic-soft-check/outcomes/eligible-targeted.html
@@ -35,7 +35,7 @@
           The children of {{ data["parent-firstname"] or "Idella" }} {{ data["parent-surname"] or "Nolan" }} {{ outcomeMessage }}
         </h3>
 
-       <p class="govuk-body">
+       <!-- <p class="govuk-body">
   <strong>Support level:</strong>
 
   <strong class="govuk-tag
@@ -47,10 +47,42 @@
   ">
     {{ policyLabel }}
   </strong>
-</p>
+</p> -->
       </div>
 
     </div>
+
+
+    <h2 class="govuk-heading-m">Eligibility details</h2>
+
+<dl class="govuk-summary-list">
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Status</dt>
+    <dd class="govuk-summary-list__value">
+      <strong class="govuk-tag
+        {% if eligibilityType == 'targeted' %}
+          govuk-tag--purple
+        {% else %}
+          govuk-tag--green
+        {% endif %}
+      ">
+        {% if eligibilityType == "targeted" %}
+          Eligible targeted
+        {% else %}
+          Eligible expanded
+        {% endif %}
+      </strong>
+    </dd>
+  </div>
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Eligibility end date</dt>
+    <dd class="govuk-summary-list__value">31 March 2026</dd>
+  </div>
+
+</dl>
+
 
     <p>This information should be passed on to their school.</p>
       <p>You can <a href="" class="govuk-link" onclick="printPage()">print this page</a> for the parent or guardian to keep.</p>

--- a/app/views/FSM/Private_beta/v8-1/en/LA_Basic/basic-manage/basic-soft-check/checker.html
+++ b/app/views/FSM/Private_beta/v8-1/en/LA_Basic/basic-manage/basic-soft-check/checker.html
@@ -1,177 +1,97 @@
 {% extends "layouts/FSM/v8-1/basic/layout-dfe-basic-lanav.html" %}
 
-{% set pageName="Run a check for one parent or guardian" %}
+{% set t = {
+  pageName: "Run a check for one parent or guardian",
+  intro: "Enter the details of the parent or guardian who applied for free school meals.",
+  firstName: "First name",
+  lastName: "Last name",
+  dateOfBirth: "Date of birth",
+  dobHint: "For example, 31 3 1980",
+  niNumber: "National Insurance number",
+  niHint: "For example, QQ 12 34 56 C",
+  asylumLink: "Parent or guardian is an asylum seeker",
+  button: "Run check"
+} %}
 
+{% set pageName = t.pageName %}
 
 {% block beforeContent %}
-{% include "_includes/layouts/back_link.html" %}
+  {% include "_includes/layouts/back_link.html" %}
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+
     <form action="checking-basic-loader.html" method="post" novalidate>
 
-      {% call govukFieldset({
-      legend: {
-      text: pageName,
-      classes: "govuk-fieldset__legend--l",
-      isPageHeading: false
-      }
-      }) %}
-      {% call govukFieldset({
-      legend: {
-      text: "",
-      classes: "govuk-fieldset__legend--l",
-      isPageHeading: true
-      }
-      }) %}
-      <p class="govuk-body">Enter the details of the parent or guardian who applied for free school meals.</p>
+      <h1 class="govuk-heading-l">{{ t.pageName }}</h1>
 
-      <hr class="govuk-section-break govuk-section-break--m govuk-section-break">
-      <!--{% endcall %} -->
+      <p class="govuk-body">{{ t.intro }}</p>
 
       {{ govukInput({
-      label: {
-      text: "First name"
-       },
-      id: "parent-firstname",
-      name: "parent-firstname",
-      autocomplete: "name",
-      classes: "govuk-input--width-20",
-      spellcheck: false
+        label: {
+          text: t.firstName
+        },
+        id: "parent-firstname",
+        name: "parent-firstname",
+        autocomplete: "given-name",
+        classes: "govuk-input--width-20",
+        spellcheck: false
       }) }}
 
       {{ govukInput({
-      label: {
-      text: "Last name"
-      },
-      id: "parent-surname",
-      name: "parent-surname",
-      autocomplete: "name",
-      classes: "govuk-input--width-20",
-
-      spellcheck: false
+        label: {
+          text: t.lastName
+        },
+        id: "parent-surname",
+        name: "parent-surname",
+        autocomplete: "family-name",
+        classes: "govuk-input--width-20",
+        spellcheck: false
       }) }}
-
-      <!-- {{ govukInput({
-      label: {
-      text: "Email address"
-      },
-      id: "email",
-      name: "email",
-      autocomplete: "name",
-      classes: "govuk-input--width-20",
-      spellcheck: false
-      }) }} -->
 
       {{ govukDateInput({
-
-      id: "dob",
-      namePrefix: "dob",
-      fieldset: {
-      legend: {
-      text: "Date of birth",
-      isPageHeading: false,
-      classes: "govuk-fieldset__legend--s"
-      }
-      },
-      hint: {
-      text: "For example, 31 3 1980"
-      }
+        id: "dob",
+        namePrefix: "dob",
+        fieldset: {
+          legend: {
+            text: t.dateOfBirth,
+            isPageHeading: false,
+            classes: "govuk-fieldset__legend--s"
+          }
+        },
+        hint: {
+          text: t.dobHint
+        }
       }) }}
-
-      {% from "govuk/components/input/macro.njk" import govukInput %}
 
       {{ govukInput({
-      label: {
-      text: "National Insurance number",
-
-      classes: "govuk-fieldset__legend--s"
-      },
-      hint: {
-      text: "For example, ‘QQ 12 34 56 C’"
-      },
-      classes: "govuk-input--width-10 govuk-input--extra-letter-spacing",
-      id: "national-insurance-number",
-      name: "nationalInsuranceNumber",
-      spellcheck: false
+        label: {
+          text: t.niNumber,
+          classes: "govuk-fieldset__legend--s"
+        },
+        hint: {
+          text: t.niHint
+        },
+        classes: "govuk-input--width-10 govuk-input--extra-letter-spacing",
+        id: "national-insurance-number",
+        name: "nationalInsuranceNumber",
+        spellcheck: false
       }) }}
 
-      <p class="govuk-body"><a class="govuk-link" rel="noreferrer noopener" target="_blank" href="../guidance/evidence-guidance.html#accordion-default-content-2">Parent or guardian is an asylum seeker</a></p>
-
-      <!--
-            {% set niHtml %}
-            {{ govukInput({
-            id: "ni-number-entered",
-            name: "ni-number-entered",
-            type: "text",
-            autocomplete: "text",
-            spellcheck: false,
-            classes: "govuk-!-width-one-third",
-            label: {
-            text:"Parent or guardian National Insurance number"
-            }
-
-            }) }}
-            {% endset -%}
-
-            {% set asrHtml %}
-            {{ govukInput({
-            id: "asr-number-entered",
-            name: "asr-number-entered",
-            type: "text",
-            autocomplete: "text",
-            spellcheck: false,
-            classes: "govuk-!-width-one-third",
-            label: {
-            text:"Parent or guardian asylum support reference number"
-            }
-
-
-            }) }}
-            {% endset -%}
-            {{ govukRadios({
-            name: "ni-number",
-            id:'ni-number',
-            fieldset: {
-            legend: {
-            text: "National Insurance number",
-            isPageHeading: false,
-            classes: "govuk-fieldset__legend--m"
-            }
-
-            },
-
-            hint: {
-            text: ""
-            },
-
-            items: [
-            {
-            value: "ni-number",
-            text: "National Insurance number",
-            conditional: {
-            html: niHtml
-            }
-            },
-            {
-            }
-
-            ]
-            }) }} -->
-
-      {% endcall %}
+      <p class="govuk-body">
+        <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="../guidance/evidence-guidance.html#accordion-default-content-2">
+          {{ t.asylumLink }}
+        </a>
+      </p>
 
       {{ govukButton({
-      text: "Run check",
-      href: "checking-basic-loader.html"
+        text: t.button
       }) }}
-      <!-- <button type="submit" class="govuk-button">Run check</button> -->
+
     </form>
+
   </div>
 </div>
-</div>
-
-
 {% endblock %}

--- a/app/views/_includes/la/v8-1/filter-panel-la-exp.html
+++ b/app/views/_includes/la/v8-1/filter-panel-la-exp.html
@@ -97,7 +97,7 @@
               },
               {
                 value: "status-in-review",
-                text: "In review"
+                text: "Application in review"
               }
             ]
           }) }}
@@ -116,7 +116,7 @@
             items: [
               {
                 value: "status-finalised",
-                text: "Finalised"
+                text: "Completed"
               },
               {
                 value: "status-recheck-due",

--- a/app/views/_includes/la/v8-1/la-table-rows.html
+++ b/app/views/_includes/la/v8-1/la-table-rows.html
@@ -7,18 +7,21 @@
     <td class="govuk-table__cell">{{ "2018-09-20" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Oakwood High</td>
     <td class="govuk-table__cell">{{ "2020-09-25" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">FSM eligible expanded</strong><br>
+    <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Eligible expanded</strong><br>
 </td>
   </tr>
 
-  <tr class="govuk-table__row matches-filters" data-school="Oakwood High" data-status="In review" data-phase="Primary" data-submission-date="2018-09-20">
+  <tr class="govuk-table__row matches-filters" data-school="Oakwood High" data-status="Application in review" data-phase="Primary" data-submission-date="2018-09-20">
     <th scope="row" class="govuk-table__header"><a href="/FSM/Private_beta/v8-1/LA/la-manage/decision/records/archived/view_45678765">45678765</a></th>
     <td class="govuk-table__cell">Alex Jones</td>
     <td class="govuk-table__cell">Theo Jones</td>
     <td class="govuk-table__cell">{{ "2018-06-10" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Oakwood High</td>
     <td class="govuk-table__cell">{{ "2018-09-20" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">In review</strong></td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
+    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">Application in review</strong></td>
   </tr>
 
   <tr class="govuk-table__row matches-filters" data-school="Springfield Primary" data-status="Evidence needed" data-phase="Primary" data-submission-date="2018-09-20">
@@ -28,6 +31,8 @@
     <td class="govuk-table__cell">{{ "2018-06-10" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Springfield Primary</td>
     <td class="govuk-table__cell">{{ "2018-09-20" | govukDate("truncate") }}</td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
     <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">Evidence needed</strong></td>
   </tr>
 
@@ -38,6 +43,8 @@
     <td class="govuk-table__cell">{{ "2017-12-03" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Oakfield Primary School</td>
     <td class="govuk-table__cell">{{ "2023-09-25" | govukDate("truncate") }}</td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
     <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">Evidence needed</strong></td>
   </tr>
 
@@ -48,27 +55,33 @@
     <td class="govuk-table__cell">{{ "2017-12-13" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Springfield Primary School</td>
     <td class="govuk-table__cell">{{ "2023-09-25" | govukDate("truncate") }}</td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
     <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--red">Not eligible</strong></td>
   </tr>
 
-  <tr class="govuk-table__row matches-filters" data-school="Beacon View school" data-status="In review" data-phase="Primary" data-submission-date="2024-05-18">
+  <tr class="govuk-table__row matches-filters" data-school="Beacon View school" data-status="Application in review" data-phase="Primary" data-submission-date="2024-05-18">
     <th scope="row" class="govuk-table__header"><a href="/FSM/Private_beta/v8-1/LA/la-manage/decision/records/in-review/47031485.html">47031485</a></th>
     <td class="govuk-table__cell">Martin Gislason</td>
     <td class="govuk-table__cell">Aleysha Gislason</td>
     <td class="govuk-table__cell">{{ "2018-12-17" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Beacon View school</td>
     <td class="govuk-table__cell">{{ "2024-05-18" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">In review</strong></td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
+    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">Application in review</strong></td>
   </tr>
 
-  <tr class="govuk-table__row matches-filters" data-school="Silver Birch Primary School" data-status="Finalised" data-phase="Primary" data-submission-date="2024-05-27">
+  <tr class="govuk-table__row matches-filters" data-school="Silver Birch Primary School" data-status="Completed targeted" data-phase="Primary" data-submission-date="2024-05-27">
     <th scope="row" class="govuk-table__header"><a href="#">44398199</a></th>
     <td class="govuk-table__cell">Koby Cruickshank</td>
     <td class="govuk-table__cell">India Cruickshank</td>
     <td class="govuk-table__cell">{{ "2021-05-26" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Silver Birch Primary School</td>
     <td class="govuk-table__cell">{{ "2024-05-27" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--turquoise">Finalised</strong></td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
+    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--turquoise">Completed targeted</strong></td>
   </tr>
 
   <tr class="govuk-table__row matches-filters" data-school="Meadowpark school" data-status="Evidence needed" data-phase="Primary" data-submission-date="2024-07-13">
@@ -78,6 +91,8 @@
     <td class="govuk-table__cell">{{ "2018-08-02" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Meadowpark school</td>
     <td class="govuk-table__cell">{{ "2024-07-13" | govukDate("truncate") }}</td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
     <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">Evidence needed</strong></td>
   </tr>
 
@@ -88,7 +103,9 @@
     <td class="govuk-table__cell">{{ "2018-05-30" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Brookside Primary School</td>
     <td class="govuk-table__cell">{{ "2024-05-05" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--purple">FSM eligible targeted</strong></td>
+     <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
+    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--purple">Eligible targeted</strong></td>
   </tr>
 
   <tr class="govuk-table__row matches-filters" data-school="Kingsmead High School" data-status="FSM eligible expanded" data-phase="Primary" data-submission-date="2024-08-10">
@@ -98,7 +115,9 @@
     <td class="govuk-table__cell">{{ "2018-12-11" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Kingsmead High School</td>
     <td class="govuk-table__cell">{{ "2024-08-10" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">FSM eligible expanded</strong></td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
+    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Eligible expanded</strong></td>
   </tr>
 
   <tr class="govuk-table__row matches-filters" data-school="Westhaven High" data-status="Evidence needed" data-phase="Primary" data-submission-date="2024-08-22">
@@ -108,6 +127,8 @@
     <td class="govuk-table__cell">{{ "2018-11-28" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Westhaven High</td>
     <td class="govuk-table__cell">{{ "2024-08-22" | govukDate("truncate") }}</td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
     <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">Evidence needed</strong></td>
   </tr>
 
@@ -118,7 +139,9 @@
     <td class="govuk-table__cell">{{ "2021-08-06" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">St George's Primary</td>
     <td class="govuk-table__cell">{{ "2024-05-05" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">FSM eligible expanded</strong></td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
+    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Eligible expanded</strong></td>
   </tr>
 
   <tr class="govuk-table__row matches-filters" data-school="Parklands Junior School" data-status="Not eligible" data-phase="Primary" data-submission-date="2024-05-25">
@@ -128,6 +151,8 @@
     <td class="govuk-table__cell">{{ "2021-11-06" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Parklands Junior School</td>
     <td class="govuk-table__cell">{{ "2024-05-25" | govukDate("truncate") }}</td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
     <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--red">Not eligible</strong></td>
   </tr>
 
@@ -138,7 +163,9 @@
     <td class="govuk-table__cell">{{ "2020-11-28" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Southfield Primary</td>
     <td class="govuk-table__cell">{{ "2024-05-05" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--purple">FSM eligible targeted</strong></td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
+    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--purple">Eligible targeted</strong></td>
   </tr>
 
   <tr class="govuk-table__row matches-filters" data-school="Millbridge Primary School" data-status="FSM eligible expanded" data-phase="Primary" data-submission-date="2024-07-03">
@@ -148,17 +175,21 @@
     <td class="govuk-table__cell">{{ "2020-07-12" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Millbridge Primary School</td>
     <td class="govuk-table__cell">{{ "2024-07-03" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">FSM eligible expanded</strong></td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
+    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Eligible expanded</strong></td>
   </tr>
 
-  <tr class="govuk-table__row matches-filters" data-school="Oakwood High" data-status="In review" data-phase="Primary" data-submission-date="2024-03-28">
+  <tr class="govuk-table__row matches-filters" data-school="Oakwood High" data-status="Application in review" data-phase="Primary" data-submission-date="2024-03-28">
     <th scope="row" class="govuk-table__header"><a href="#">76217312</a></th>
     <td class="govuk-table__cell">Priya Patel</td>
     <td class="govuk-table__cell">Asha Patel</td>
     <td class="govuk-table__cell">{{ "2020-02-15" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Oakwood High</td>
     <td class="govuk-table__cell">{{ "2024-03-28" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">In review</strong></td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
+    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">Application in review</strong></td>
   </tr>
 
   <tr class="govuk-table__row matches-filters" data-school="Willow Grove Primary School" data-status="Not eligible" data-phase="Primary" data-submission-date="2024-07-23">
@@ -168,6 +199,8 @@
     <td class="govuk-table__cell">{{ "2021-01-21" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Willow Grove Primary School</td>
     <td class="govuk-table__cell">{{ "2024-07-23" | govukDate("truncate") }}</td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
     <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--red">Not eligible</strong></td>
   </tr>
 
@@ -178,6 +211,8 @@
     <td class="govuk-table__cell">{{ "2018-04-24" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Cedar Ridge Primary School</td>
     <td class="govuk-table__cell">{{ "2024-07-17" | govukDate("truncate") }}</td>
+     <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
     <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">Evidence needed</strong></td>
   </tr>
 
@@ -188,6 +223,8 @@
     <td class="govuk-table__cell">{{ "2019-02-26" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Meadowpark Primary School</td>
     <td class="govuk-table__cell">{{ "2024-07-26" | govukDate("truncate") }}</td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
     <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey">Archived</strong></td>
   </tr>
 
@@ -198,17 +235,21 @@
     <td class="govuk-table__cell">{{ "2019-03-03" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Brookside Primary School</td>
     <td class="govuk-table__cell">{{ "2024-06-27" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">FSM eligible expanded</strong></td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
+    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Eligible expanded</strong></td>
   </tr>
 
-  <tr class="govuk-table__row matches-filters" data-school="Westhaven High" data-status="In review" data-phase="Primary" data-submission-date="2024-08-10">
+  <tr class="govuk-table__row matches-filters" data-school="Westhaven High" data-status="Application in review" data-phase="Primary" data-submission-date="2024-08-10">
     <th scope="row" class="govuk-table__header"><a href="#">43346257</a></th>
     <td class="govuk-table__cell">Randall Stamm-Feest</td>
     <td class="govuk-table__cell">Sarah Taylor-Stamm</td>
     <td class="govuk-table__cell">{{ "2018-11-15" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Westhaven High</td>
     <td class="govuk-table__cell">{{ "2024-08-10" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">In review</strong></td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
+    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">Application in review</strong></td>
   </tr>
 
   <tr class="govuk-table__row matches-filters" data-school="Hilltop Primary School" data-status="FSM eligible expanded" data-phase="Primary" data-submission-date="2024-06-01">
@@ -218,7 +259,9 @@
     <td class="govuk-table__cell">{{ "2018-12-24" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Hilltop Primary School</td>
     <td class="govuk-table__cell">{{ "2024-06-01" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">FSM eligible expanded</strong></td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
+    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Eligible expanded</strong></td>
   </tr>
 
   <tr class="govuk-table__row matches-filters" data-school="Greenfield Primary School" data-status="Evidence needed" data-phase="Primary" data-submission-date="2024-08-12">
@@ -228,6 +271,8 @@
     <td class="govuk-table__cell">{{ "2020-05-12" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Greenfield Primary School</td>
     <td class="govuk-table__cell">{{ "2024-08-12" | govukDate("truncate") }}</td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
     <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">Evidence needed</strong></td>
   </tr>
 
@@ -238,7 +283,9 @@
     <td class="govuk-table__cell">{{ "2019-10-19" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Elmwood Primary School</td>
     <td class="govuk-table__cell">{{ "2024-05-17" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--purple">FSM eligible targeted</strong></td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
+    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--purple">Eligible targeted</strong></td>
   </tr>
 
   <tr class="govuk-table__row matches-filters" data-school="Kingsmead High School"   data-status="Not eligible" data-phase="Primary" data-submission-date="2024-06-24">
@@ -248,6 +295,8 @@
     <td class="govuk-table__cell">{{ "2021-06-18" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Kingsmead High School</td>
     <td class="govuk-table__cell">{{ "2024-06-24" | govukDate("truncate") }}</td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
     <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--red">Not eligible</strong></td>
   </tr>
 
@@ -258,7 +307,9 @@
     <td class="govuk-table__cell">{{ "2020-02-20" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Parklands Junior School</td>
     <td class="govuk-table__cell">{{ "2024-05-06" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">FSM eligible expanded</strong></td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
+    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Eligible expanded</strong></td>
   </tr>
 
   <tr class="govuk-table__row matches-filters" data-school="St George's Primary" data-status="FSM eligible targeted" data-phase="Primary" data-submission-date="2024-07-19">
@@ -268,7 +319,9 @@
     <td class="govuk-table__cell">{{ "2020-10-22" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">St George's Primary</td>
     <td class="govuk-table__cell">{{ "2024-07-19" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--purple">FSM Eligible targeted</strong></td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
+    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--purple">Eligible targeted</strong></td>
   </tr>
 
   <tr class="govuk-table__row matches-filters" data-school="Southfield Primary School" data-status="Evidence needed" data-phase="Primary" data-submission-date="2024-08-17">
@@ -278,6 +331,8 @@
     <td class="govuk-table__cell">{{ "2021-08-03" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Southfield Primary School</td>
     <td class="govuk-table__cell">{{ "2024-08-17" | govukDate("truncate") }}</td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
     <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">Evidence needed</strong></td>
   </tr>
 
@@ -288,7 +343,9 @@
     <td class="govuk-table__cell">{{ "2021-05-22" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Parklands Junior School</td>
     <td class="govuk-table__cell">{{ "2024-05-18" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">FSM eligible expanded</strong></td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
+    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Eligible expanded</strong></td>
   </tr>
 
   <tr class="govuk-table__row matches-filters" data-school="Oakwood High" data-status="Evidence needed" data-phase="Primary" data-submission-date="2024-07-07">
@@ -298,17 +355,21 @@
     <td class="govuk-table__cell">{{ "2019-09-04" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Oakwood High</td>
     <td class="govuk-table__cell">{{ "2024-07-07" | govukDate("truncate") }}</td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
     <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">Evidence needed</strong></td>
   </tr>
 
-  <tr class="govuk-table__row matches-filters" data-school="Parklands Junior School" data-status="In review" data-phase="Primary" data-submission-date="2024-07-31">
+  <tr class="govuk-table__row matches-filters" data-school="Parklands Junior School" data-status="Application in review" data-phase="Primary" data-submission-date="2024-07-31">
     <th scope="row" class="govuk-table__header"><a href="#">92548396</a></th>
     <td class="govuk-table__cell">Charles Rothbury</td>
     <td class="govuk-table__cell">Lydia Rothbury</td>
     <td class="govuk-table__cell">{{ "2018-01-12" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Parklands Junior School</td>
     <td class="govuk-table__cell">{{ "2024-07-31" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">In review</strong></td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
+    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">Application in review</strong></td>
   </tr>
 
   <tr class="govuk-table__row matches-filters" data-school="Hilltop Primary School" data-status="FSM eligible targeted" data-phase="Primary" data-submission-date="2024-07-09">
@@ -318,6 +379,8 @@
     <td class="govuk-table__cell">{{ "2018-12-02" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">Hilltop Primary School</td>
     <td class="govuk-table__cell">{{ "2024-07-09" | govukDate("truncate") }}</td>
+        <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
+
     <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--purple">Eligible targeted</strong></td>
   </tr>
 


### PR DESCRIPTION
Add a new translations file for FSM checker pages (English & Welsh) and refactor the basic checker view to use a localised text object with improved labels, hints and autocomplete.

Update LA and LA_Basic outcome templates to display eligibility details and end dates (showing an eligibility end date and an end date variable), and reveal/hide support level markup.

Add an End date column to the LA report and populate rows with a fixed end date. Standardise status labels across the filter panel, table rows and JS mappings (e.g. "In review" -> "Application in review", "Finalised" -> "Completed/Completed targeted", and simplify "FSM eligible ..." labels to "Eligible ...").