### PR TITLE
Update LA templates and status labels to 'In MIS'

### DIFF
--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/la-soft-check/outcomes/eligible-expanded.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/la-soft-check/outcomes/eligible-expanded.html
@@ -34,7 +34,7 @@
         <h3 class="govuk-notification-banner__heading">
           The children of {{ data["parent-firstname"] or "Derrick" }} {{ data["parent-surname"] or "Stark" }} {{ outcomeMessage }}
         </h3>
-
+<!--
        <p class="govuk-body">
   <strong>Support level:</strong>
 
@@ -47,10 +47,45 @@
   ">
     {{ policyLabel }}
   </strong>
-</p>
+</p> -->
+
+
       </div>
 
     </div>
+
+
+
+
+<h2 class="govuk-heading-m">Eligibility details</h2>
+
+<dl class="govuk-summary-list">
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Status</dt>
+    <dd class="govuk-summary-list__value">
+      <strong class="govuk-tag
+        {% if eligibilityType == 'targeted' %}
+          govuk-tag--purple
+        {% else %}
+          govuk-tag--green
+        {% endif %}
+      ">
+        {% if eligibilityType == "targeted" %}
+          Eligible targeted
+        {% else %}
+          Eligible expanded
+        {% endif %}
+      </strong>
+    </dd>
+  </div>
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Eligibility end date</dt>
+    <dd class="govuk-summary-list__value">31 August 2026</dd>
+  </div>
+
+</dl>
 
     <p>This information should be passed on to their school.</p>
 

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/la-soft-check/outcomes/eligible-targeted.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/la-soft-check/outcomes/eligible-targeted.html
@@ -35,7 +35,7 @@
         <h3 class="govuk-notification-banner__heading">
           The children of {{ data["parent-firstname"] or "Idella" }} {{ data["parent-surname"] or "Nolan" }} {{ outcomeMessage }}
         </h3>
-
+<!--
        <p class="govuk-body">
   <strong>Support level:</strong>
 
@@ -48,14 +48,49 @@
   ">
     {{ policyLabel }}
   </strong>
-</p>
+</p> -->
       </div>
 
     </div>
 
 
 
-    <p>This information should be passed on to their school.</p>
+
+<h2 class="govuk-heading-m">Eligibility details</h2>
+
+<dl class="govuk-summary-list">
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Status</dt>
+    <dd class="govuk-summary-list__value">
+      <strong class="govuk-tag
+        {% if eligibilityType == 'targeted' %}
+          govuk-tag--purple
+        {% else %}
+          govuk-tag--green
+        {% endif %}
+      ">
+        {% if eligibilityType == "targeted" %}
+          Eligible targeted
+        {% else %}
+          Eligible expanded
+        {% endif %}
+      </strong>
+    </dd>
+  </div>
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Eligibility end date</dt>
+    <dd class="govuk-summary-list__value">31 August 2026</dd>
+  </div>
+
+</dl>
+
+  <!-- <p>This check is valid until the end date shown at which time a recheck will need to be done to confirm if the children are still eligible.</p> -->
+  <p>This information should be passed on to their school.</p>
+
+
+
 
     <div class="govuk-button-group">
       <a href="../checker" class="govuk-button" role="button" data-module="govuk-button">

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/report/search.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/report/search.html
@@ -140,7 +140,7 @@ document.addEventListener('DOMContentLoaded', () => {
     'status-not-eligible': 'Not eligible',
     'status-evidence-needed': 'Evidence needed',
     'status-in-review': 'Application in review',
-    'status-finalised': 'Completed targeted',
+    'status-finalised': 'In MIS',
     'status-archived': 'Archived'
   };
 

--- a/app/views/FSM/Private_beta/v8-1/LA_Basic/basic-manage/basic-soft-check/outcomes/eligible-expanded.html
+++ b/app/views/FSM/Private_beta/v8-1/LA_Basic/basic-manage/basic-soft-check/outcomes/eligible-expanded.html
@@ -79,7 +79,7 @@
 
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">Eligibility end date</dt>
-    <dd class="govuk-summary-list__value">31 March 2026</dd>
+    <dd class="govuk-summary-list__value">31 August 2026</dd>
   </div>
 
 </dl>

--- a/app/views/FSM/Private_beta/v8-1/LA_Basic/basic-manage/basic-soft-check/outcomes/eligible-targeted.html
+++ b/app/views/FSM/Private_beta/v8-1/LA_Basic/basic-manage/basic-soft-check/outcomes/eligible-targeted.html
@@ -53,7 +53,7 @@
     </div>
 
 
-    <h2 class="govuk-heading-m">Eligibility details</h2>
+<h2 class="govuk-heading-m">Eligibility details</h2>
 
 <dl class="govuk-summary-list">
 
@@ -78,7 +78,7 @@
 
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">Eligibility end date</dt>
-    <dd class="govuk-summary-list__value">31 March 2026</dd>
+    <dd class="govuk-summary-list__value">31 August 2026</dd>
   </div>
 
 </dl>

--- a/app/views/FSM/Private_beta/v8-1/LA_Basic/dashboard.html
+++ b/app/views/FSM/Private_beta/v8-1/LA_Basic/dashboard.html
@@ -1,6 +1,6 @@
 {% extends "layouts/FSM/v8-1/basic/layout-dfe-basic-lanav.html" %}
 
-{% set pageName="Manchestrer Council" %}
+{% set pageName="Manchester Council" %}
 {% set Service="Manage eligibility for free school meals" %}
 {% set view="dashboard" %}
 {% set VERSION ="v8-0" %}

--- a/app/views/_includes/la/v8-1/filter-panel-la-exp.html
+++ b/app/views/_includes/la/v8-1/filter-panel-la-exp.html
@@ -116,7 +116,7 @@
             items: [
               {
                 value: "status-finalised",
-                text: "Completed"
+                text: "In MIS"
               },
               {
                 value: "status-recheck-due",

--- a/app/views/_includes/la/v8-1/la-table-rows.html
+++ b/app/views/_includes/la/v8-1/la-table-rows.html
@@ -72,7 +72,7 @@
     <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">Application in review</strong></td>
   </tr>
 
-  <tr class="govuk-table__row matches-filters" data-school="Silver Birch Primary School" data-status="Completed targeted" data-phase="Primary" data-submission-date="2024-05-27">
+  <tr class="govuk-table__row matches-filters" data-school="Silver Birch Primary School" data-status="In MIS" data-phase="Primary" data-submission-date="2024-05-27">
     <th scope="row" class="govuk-table__header"><a href="#">44398199</a></th>
     <td class="govuk-table__cell">Koby Cruickshank</td>
     <td class="govuk-table__cell">India Cruickshank</td>
@@ -81,7 +81,7 @@
     <td class="govuk-table__cell">{{ "2024-05-27" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
-    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--turquoise">Completed targeted</strong></td>
+    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--turquoise">In MIS - targeted</strong></td>
   </tr>
 
   <tr class="govuk-table__row matches-filters" data-school="Meadowpark school" data-status="Evidence needed" data-phase="Primary" data-submission-date="2024-07-13">


### PR DESCRIPTION
Add an "Eligibility details" summary block to LA outcome templates and comment out the previous support-level paragraph; update eligibility end dates to 31 August 2026. Rename status labels from "Completed"/"Completed targeted" to "In MIS" (and table display to "In MIS - targeted"), and update the filter option and JS mapping accordingly. Also fix a typo on the basic dashboard (Manchestrer → Manchester). These changes align UI copy and dates with MIS requirements.