### PR TITLE
Enable section breaks and add batch actions

### DIFF
--- a/app/views/FSM/Private_beta/v8-1/LA/guidance.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/guidance.html
@@ -17,7 +17,7 @@
 
     <p></p>
 
-         <!-- <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"> -->
+         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
              <h2 class="govuk-heading-m">Run a batch check</h2>
 

--- a/app/views/FSM/Private_beta/v8-1/LA_Basic/basic-manage/basic-soft-check/outcomes/eligible-expanded.html
+++ b/app/views/FSM/Private_beta/v8-1/LA_Basic/basic-manage/basic-soft-check/outcomes/eligible-expanded.html
@@ -105,7 +105,7 @@
 
 <!-- <h2 class="govuk-heading-m">Result and annual rechecks</h2> -->
  <p class="govuk-body">The result of this check is valid for the academic year {{ academicYear }}. You must complete annual rechecks to confirm ongoing eligibility. </p>
-    <p class="govuk-body"><a href="../../guidance/recheck-guidance" class="govuk-link">How and when to complete annual rechecks</a></p>
+    <p class="govuk-body"><a href="../../guidance/guidance-steps/rechecks.html" class="govuk-link">How and when to complete annual rechecks</a></p>
 
 
 
@@ -123,12 +123,19 @@
 </div>
 
 
-      <p class="govuk-body">You can <a href="" class="govuk-link" onclick="printPage()">print this page</a> for the parent or guardian to keep.</p>
-    <script>
-      function printPage() {
-        window.print();
-      }
-    </script>
+<p class="govuk-body">
+  You can
+  <a href="#" class="govuk-link" onclick="printPage(); return false;">
+    print this page
+  </a>
+  for the parent or guardian to keep.
+</p>
+
+<script>
+  function printPage() {
+    window.print();
+  }
+</script>
 
 
     <div class="govuk-button-group">

--- a/app/views/FSM/Private_beta/v8-1/LA_Basic/basic-manage/basic-soft-check/outcomes/eligible-targeted.html
+++ b/app/views/FSM/Private_beta/v8-1/LA_Basic/basic-manage/basic-soft-check/outcomes/eligible-targeted.html
@@ -63,7 +63,7 @@
 
 <!-- <h2 class="govuk-heading-m">Result and annual rechecks</h2> -->
  <p class="govuk-body">The result of this check is valid for the academic year {{ academicYear }}. You must complete annual rechecks to confirm ongoing eligibility. </p>
-    <p class="govuk-body"><a href="../../guidance/recheck-guidance" class="govuk-link">How and when to complete annual rechecks</a></p>
+    <p class="govuk-body"><a href="../../guidance/guidance-steps/rechecks.html" class="govuk-link">How and when to complete annual rechecks</a></p>
 
 
 

--- a/app/views/FSM/Private_beta/v8-1/LA_Basic/basic-manage/batch-checking/submitted-completed.html
+++ b/app/views/FSM/Private_beta/v8-1/LA_Basic/basic-manage/batch-checking/submitted-completed.html
@@ -94,13 +94,10 @@ File submitted
           <td class="govuk-table__cell">{{ dateSubmitted | duration(6, 'days') | govukDate }} 11.54am</td>
           <!-- <td class="govuk-table__cell">Matthew Smith</td> -->
           <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Completed</strong></td>
-          <td class="govuk-table__cell"><a href="#">Download results</a>
+         <td class="govuk-table__cell"><a href="#">Download results</a> | <a href="#">Delete</a></td>
+          <td class="govuk-table__cell"></td>
 
-          <!-- <td class="govuk-table__cell"><a href="./results/batch-check-success.html">View results</a> -->
-          </td>
-          <!-- <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Completed</strong></td> -->
-          <!-- <td class="govuk-table__cell"><a href="/public/csv/">View results</a>  | <a href="/ /batch-check/history/delete-file">Delete</a></td> -->
-          <td class="govuk-table__cell"><a href=""> </a></td>
+
         </tr>
 
       </tbody>

--- a/app/views/FSM/Private_beta/v8-1/LA_Basic/basic-manage/batch-checking/submitted-in-progress.html
+++ b/app/views/FSM/Private_beta/v8-1/LA_Basic/basic-manage/batch-checking/submitted-in-progress.html
@@ -95,13 +95,8 @@ File submitted
           <td class="govuk-table__cell">{{ dateSubmitted | duration(6, 'days') | govukDate }} 11.54am</td>
           <!-- <td class="govuk-table__cell">Matthew Smith</td> -->
           <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Completed</strong></td>
-          <td class="govuk-table__cell"><a href="#">Download results</a>
-
-          <!-- <td class="govuk-table__cell"><a href="./results/batch-check-success.html">View results</a> -->td class="govuk-table__cell"><a href="./results/batch-check-success.html">View results</a>
-          </td>
-          <!-- <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Completed</strong></td> -->
-          <!-- <td class="govuk-table__cell"><a href="/public/csv/">View results</a>  | <a href="/ /batch-check/history/delete-file">Delete</a></td> -->
-          <td class="govuk-table__cell"><a href=""> </a></td>
+          <td class="govuk-table__cell"><a href="#">Download results</a> | <a href="#">Delete</a></td>
+          <td class="govuk-table__cell"></td>
         </tr>
 
 

--- a/app/views/FSM/Private_beta/v8-1/LA_Basic/basic-manage/batch-checking/submitted-not-started.html
+++ b/app/views/FSM/Private_beta/v8-1/LA_Basic/basic-manage/batch-checking/submitted-not-started.html
@@ -99,14 +99,8 @@ File submitted
           <td class="govuk-table__cell">{{ dateSubmitted | duration(6, 'days') | govukDate }} 11.54am</td>
           <td class="govuk-table__cell">Matthew Smith</td>
           <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Completed</strong></td>
-          <!-- <td class="govuk-table__cell"><a href="./results/batch-check-success.html">Download results</a> -->
-          <td class="govuk-table__cell"><a href="#">Download results</a>
-
-          <!-- <td class="govuk-table__cell"><a href="./results/batch-check-success.html">View results</a> -->
-          </td>
-          <!-- <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Completed</strong></td> -->
-          <!-- <td class="govuk-table__cell"><a href="/public/csv/">View results</a>  | <a href="/ /batch-check/history/delete-file">Delete</a></td> -->
-          <td class="govuk-table__cell"><a href=""> </a></td>
+          <td class="govuk-table__cell"><a href="#">Download results</a> | <a href="#">Delete</a></td>
+          <td class="govuk-table__cell"></td>
         </tr>
 
       </tbody>

--- a/app/views/FSM/Private_beta/v8-1/LA_Basic/basic-manage/guidance/guidance.html
+++ b/app/views/FSM/Private_beta/v8-1/LA_Basic/basic-manage/guidance/guidance.html
@@ -17,20 +17,29 @@
 
     <p></p>
 
-         <!-- <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"> -->
+         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
              <h2 class="govuk-heading-m">Run a batch check</h2>
 
     <p><a href="./guidance-steps/batch-check.html">Running a batch check</a></p>
+
+             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
 
 
         <h2 class="govuk-heading-m">Rechecks</h2>
 
     <p><a href="./guidance-steps/rechecks.html">Guidance for completing annual rechecks</a></p>
 
+                 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+
            <h2 class="govuk-heading-m">Targeted and expanded free school meals</h2>
 
+
+
     <p><a href="./guidance-steps/expansion.html">Free school meals: guidance for schools and local authorities</a></p>
+
 
     <!-- <p><a href="/guidance-steps/batch-check-results.html">Batch check results</a></p> -->
 


### PR DESCRIPTION
Uncomment and enable visible section breaks in LA guidance templates for clearer layout. Improve print link markup in eligible-expanded.html (use href="#", prevent default and move script) for better behaviour. Add a "Delete" action next to "Download results" and clean up table cells in batch-checking templates to expose action links for batch results management.