### PR TITLE
Mark LA Basic Expansion as signed off

### DIFF
--- a/app/views/FSM/index-fsm.html
+++ b/app/views/FSM/index-fsm.html
@@ -946,7 +946,7 @@
               <td class="govuk-table__cell"><b> Welsh LA Basic </b></a><br> Basic version with welsh toggle<br> Policy
                 expansion v1-0 <br></td>
               <td class="govuk-table__cell"><span class="govuk-tag govuk-tag--blue">Design</span></td>
-              <td class="govuk-table__cell"><a href="./Private_beta/v8-1/LA_Basic/dashboard.html"
+              <td class="govuk-table__cell"><a href="./Private_beta/v8-1/en/LA_Basic/dashboard.html"
                   class="govuk-link">Dashboard</a><br>
                 <a href="./Private_beta/v8-1/en/LA_Basic/basic-manage/basic-soft-check/checker.html"
                   class="govuk-link">Individual check</a>
@@ -967,7 +967,7 @@
               </td>
               <td class="govuk-table__cell"><b>LA Basic Expansion</b></a><br>Policy expansion v1-0<br>Update outcomes
               </td>
-              <td class="govuk-table__cell"><span class="govuk-tag govuk-tag--blue">Design</span></td>
+              <td class="govuk-table__cell"><span class="govuk-tag govuk-tag--pink">Signed off</span></td>
               <td class="govuk-table__cell"><a href="./Private_beta/v8-1/LA_Basic/dashboard.html"
                   class="govuk-link">Dashboard</a>
                 <br><a href="./Private_beta/v8-1/LA_Basic/basic-manage/basic-soft-check/checker.html"
@@ -980,6 +980,10 @@
                   class="govuk-link">Batch check</a>
                 <br><a href="./Private_beta/v8-1/LA_Basic/basic-manage/guidance/guidance.html"
                   class="govuk-link">Guidance</a>
+                 <br><a href="./Private_beta/v8-1/LA_Basic/basic-manage/guidance/guidance-steps/rechecks.html"
+                  class="govuk-link">Recheck guidance</a>
+                    <br><a href="./Private_beta/v8-1/LA_Basic/basic-manage/guidance/guidance-steps/expansion.html"
+                  class="govuk-link">Expansion guidance</a>
                 <br><a href="./Private_beta/v8-1/LA_Basic/basic-manage/report/report-checks.html"
                   class="govuk-link">Reports</a>
               <td class="govuk-table__cell govuk-table__cell--numeric">16 April 26</td>


### PR DESCRIPTION
Change the status tag for the LA Basic Expansion row from 'Design' (govuk-tag--blue) to 'Signed off' (govuk-tag--pink). Also add two guidance links under guidance steps: 'Recheck guidance' and 'Expansion guidance' (Private_beta/v8-1/LA_Basic/basic-manage/guidance/guidance-steps/). These updates reflect the feature being signed off and provide navigation to the new guidance pages.