### PR TITLE
Use v8-1 layout and update batch-check link

### DIFF
--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/batch-checking/june-launch/manual-no-ctf.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/batch-checking/june-launch/manual-no-ctf.html
@@ -1,4 +1,4 @@
-{% extends "/layouts/FSM/v8-0/layout-dfe-lanav.html" %}
+{% extends "/layouts/FSM/v8-1/layout-dfe-lanav.html" %}
 {% set pageName="Run a manual batch check" %}
 
 {% block beforeContent %}

--- a/app/views/layouts/FSM/v8-1/layout-dfe-lanav.html
+++ b/app/views/layouts/FSM/v8-1/layout-dfe-lanav.html
@@ -6,8 +6,8 @@
 {% set govukRebrand = true %}
 
 {# ------------- #}
-{% set VERSION = "v8-1" %}
-{% set ROOT = "/FSM/Private_beta/" + VERSION %}
+<!-- {% set VERSION = "v8-1" %}
+{% set ROOT = "/FSM/Private_beta/" + VERSION %} -->
 {# ------------------------- #}
 
 {# --- Single source of truth for this version --- #}
@@ -37,7 +37,7 @@
   serviceUrl: ROOT + "/LA/dashboard",
   navigation: [
     { href: ROOT + "/LA/la-manage/la-soft-check/checker.html", text: "Run a check" },
-    { href: ROOT + "/LA/la-manage/batch-checking/manual-no-ctf.html", text: "Run batch check" },
+    { href: ROOT + "/LA/la-manage/batch-checking/june-launch/manual-no-ctf.html", text: "Run batch check" },
     { href: ROOT + "/LA/la-manage/decision/pending-list", text: "Review applications" },
     { href: ROOT + "/LA/la-manage/report/search.html", text: "Search records"},
     { href: ROOT + "/LA/guidance.html", text: "Guidance" }


### PR DESCRIPTION
Switch the manual-no-ctf view to extend the v8-1 layout (was v8-0). In layout-dfe-lanav, the VERSION/ROOT assignments were commented out and the LA navigation item for "Run batch check" was updated to point to the new june-launch/manual-no-ctf.html path. This aligns the view with v8-1 and fixes the navigation target for the relocated file.