### PR TITLE
Update batch checking page copy and layout

### DIFF
--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/batch-checking/june-launch/batchcheck-summary.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/batch-checking/june-launch/batchcheck-summary.html
@@ -1,20 +1,9 @@
 {% extends "layouts/FSM/v8-1/layout-dfe-lanav.html" %}
-{% set pageName="Batch check results" %}
-
+{% set fileName = "Greenwoodprim25.xml" %}
+{% set academicYear = "2026/27" %}
+{% set submittedDate = "29 May 2026" %}
+{% set pageName="Batch check results for " + fileName + " on " + submittedDate %}
 {% block beforeContent %}
-<!--
-{% block backLink %}
-{{ govukBackLink({
-text: "Back",
-href: "javascript:window.history.back()"
-}) }}
-{% endblock %} -->
-<!--
-{% set breadcrumbs = breadcrumbs or [
-  { text: "Home", href: "/FSM/Private_beta/v7-3/LA/dashboard.html" },
-  { text: "Batch checking", href: "/FSM/Private_beta/v7-3/LA/la-manage/batch-checking/manual.html" },
-  { text: "Batch checks history" }
-] %} -->
 
 {% endblock %}
 {% block content %}
@@ -26,7 +15,7 @@ href: "javascript:window.history.back()"
 
   <div class="govuk-grid-column-full">
 
-
+<!-- <span class="govuk-caption-l"> {{ fileName }} {{ submittedDate }}</span> -->
     <h1 class="govuk-heading-l">{{ pageName }}</h1>
     <!-- <p class="govuk-body">Rechecks confirm child eligibility for the next academic year. This summary shows a record of all rechecks completed by your local authority. <br><br>We will notify you  by email when checks are completed.</p> -->
     <!-- <details class="govuk-details">
@@ -39,8 +28,7 @@ Details need to go in here  </div>
 </details> -->
 
     <!-- <p><a href="/batch-checking/history/result-explainer"></a></p> -->
-   <p class="govuk-body">Checks confirm child eligibility for the next academic year. This summary shows a record of all check completed by your local authority. </p>
-     <p class="govuk-body">You can create applications for all eligible children or download the results.</p>
+   <p class="govuk-body">Checks confirm child eligibility for the academic year {{ academicYear }}. This summary shows a record of all check completed by your local authority. </p>
 
     <table class="govuk-table govuk-table--small-text-until-tablet">
       <!-- <caption class="govuk-table__caption govuk-table__caption govuk-!-margin-bottom-4"> </caption> -->
@@ -83,6 +71,8 @@ Details need to go in here  </div>
 
       </tbody>
     </table>
+
+   <p class="govuk-body">You can create applications for all eligible children or download the results.</p>
 
 <div class="govuk-button-group">
   <button type="submit" class="govuk-button" data-module="govuk-button" onclick="window.location.href='submitted-completed-applications.html'">

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/batch-checking/june-launch/manual-no-ctf.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/batch-checking/june-launch/manual-no-ctf.html
@@ -19,7 +19,7 @@
         <div class="moj-button-group moj-button-group--inline">
           <a href="submitted-completed.html" class="govuk-button govuk-button--secondary"
             data-module="govuk-button">
-            Batch checks
+            Batch checks history
           </a>
         </div>
         <!--
@@ -36,25 +36,32 @@
       <h2 class="govuk-heading-m">Download our CSV template</h2>
       <ol class="govuk-list govuk-list--number">
         <li>Download the <a href="/public/csv/Batch-check-template.csv" download class="govuk-link">batch
-            check template (185kb)</a>.</li>
+            check template (CSV, 1KB)</a>.</li>
         <li>
-          Add the details of the {{ data['check-type'] }} you need to check as well as the children who will be added to
-          the application.</li>
+          Add the details of the parents or guardians you need to check, as well as the children who will be added to
+          the application. Add a row for each child.</li>
         <li>Make sure you include:
           <ul class="govuk-list govuk-list--bullet">
-            <li>Parent first name</li>
-            <li>Parent last name</li>
-            <li>Date of birth (format DD/MM/YYYY or YYYY-MM-DD)</li>
-            <li>National Insurance number</li>
-            <li>Childs name</li>
-            <li>Childs date of birth (format DD/MM/YYYY or YYYY-MM-DD)</li>
-            <li>School the child attends on a full time basis</li>
+            <li>parent first name</li>
+            <li>parent last name</li>
+            <li>parent date of birth (format DD/MM/YYYY or YYYY-MM-DD)</li>
+            <li>parent National Insurance number</li>
+            <li>child name</li>
+            <li>child date of birth (format DD/MM/YYYY or YYYY-MM-DD)</li>
+            <li>URN of the school the child attends on a full time basis</li>
           </ul>
         </li>
         <li> Save it as a CSV file.</li>
       </ol>
 
-      <hr class="govuk-section-break govuk-section-break--m govuk-section-break">
+      <div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-visually-hidden">Warning</span>
+Your saved file must match the template fields and contain fewer than 5000 rows.
+  </strong>
+</div>
+  <hr class="govuk-section-break govuk-section-break--m govuk-section-break">
 
       <h3 class="govuk-heading-m">Upload a CSV file</h3>
       <div class="govuk-form-group">

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/batch-checking/june-launch/submitted-completed.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/batch-checking/june-launch/submitted-completed.html
@@ -1,9 +1,7 @@
 {% extends "layouts/FSM/v8-1/layout-dfe-lanav.html" %}
-
 {% block pageTitle %}
-  File submitted
+File submitted
 {% endblock %}
-
 {% set dateSubmitted = '2026-05-22' %}
 
 
@@ -12,7 +10,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title"
+      data-module="govuk-notification-banner">
       <div class="govuk-notification-banner__header">
         <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
           File submitted
@@ -22,7 +21,8 @@
         <h3 class="govuk-notification-banner__heading">
           Your file Greenwoodprim25.xml was submitted and is ready to view.
         </h3>
-        <p>Processing time depends on file size and how many checks are currently running. View the latest status in the batch check history at any time.</p>
+        <p>Processing time depends on file size and how many checks are currently running. View the latest status in the
+          batch checks history at any time.</p>
 
 
       </div>
@@ -35,15 +35,16 @@
     <!-- <p><a href="/ /batch-check/history/result-explainer">Get help with check results</a></p> -->
 
     <table class="govuk-table govuk-table--small-text-until-tablet">
-      <caption class="govuk-table__caption govuk-table__caption--s govuk-!-margin-bottom-4">Showing 2 batch files uploaded in the last 7 days</caption>
+      <caption class="govuk-table__caption govuk-table__caption--s govuk-!-margin-bottom-4">Showing 2 batch files
+        uploaded in the last 7 days</caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header">Filename</th>
-            <th class="govuk-table__cell">Number of records</th>
+          <th class="govuk-table__cell">Number of records</th>
           <th class="govuk-table__cell">Last surname <br> </th>
           <th scope="col" class="govuk-table__header">Submitted</th>
           <th scope="col" class="govuk-table__header">Status</th>
-          <th scope="col" class="govuk-table__header"> </th>
+          <th scope="col" class="govuk-table__header">Actions</th>
           <th scope="col" class="govuk-table__header"></th>
           <th scope="col" class="govuk-table__header"></th>
           <th scope="col" class="govuk-table__header"></th>
@@ -59,30 +60,30 @@
           <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">In progress</strong></td>
           <td class="govuk-table__cell"><a href=""> </a></td>
           <td class="govuk-table__cell"><a href=""></a></td>
-                    <td class="govuk-table__cell"><a href=""></a></td>
+          <td class="govuk-table__cell"><a href=""></a></td>
 
-                    <th scope="col" class="govuk-table__header"></th>
+          <th scope="col" class="govuk-table__header"></th>
 
         </tr>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">Greenwoodprim25_1.xml</td>
-                    <td class="govuk-table__cell">1234</td>
+          <td class="govuk-table__cell">1234</td>
 
           <td class="govuk-table__cell">Warren</td>
           <td class="govuk-table__cell">{{ dateSubmitted | duration(7, 'days') | govukDate }} </td>
           <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">Checks completed</strong></td>
-                                <!-- <td class="govuk-table__cell"> Eligible targeted <br> Eligible expanded <br>Not eligible <br> Could not check</td>
+          <!-- <td class="govuk-table__cell"> Eligible targeted <br> Eligible expanded <br>Not eligible <br> Could not check</td>
 <td class="govuk-table__cell"><strong>842</strong> <br><strong>610</strong><br><strong>240</strong><br><strong>22</strong></td> -->
-                    <td class="govuk-table__cell"><a href="./batchcheck-summary.html">View results</a>
-                    </td>
-                    <td class="govuk-table__cell"><a href="./batchcheck-summary.html">Download check results</a>
-        <td class="govuk-table__cell"><a href="./batchcheck-summary.html"> </a>
-                    </tr>
+          <td class="govuk-table__cell"><a href="./batchcheck-summary.html">View results</a>
+          </td>
+          <td class="govuk-table__cell"><a href="./batchcheck-summary.html">Download check results</a>
+          <td class="govuk-table__cell"><a href="./batchcheck-summary.html"> </a>
+        </tr>
 
-                                          <!-- <td class="govuk-table__cell"><a href="./batchcheck-summary.html">Download results</a> -->
+        <!-- <td class="govuk-table__cell"><a href="./batchcheck-summary.html">Download results</a> -->
 
 
-<!--
+        <!--
           <td class="govuk-table__cell"></td>
         </tr>
 


### PR DESCRIPTION
**Revise June-launch batch checking templates to improve copy and layout.** 

Changes include:

- batchcheck-summary.html: add sample fileName, academicYear and submittedDate variables and build a more descriptive pageName; update body copy to reference the academic year and reposition related paragraph.
- manual-no-ctf.html: change CTA to "Batch checks history", clarify CSV template details and field list (use URN for school), lowercase field labels for consistency, and add a warning about saved files needing to match the template and be under 5000 rows.
- submitted-completed.html: trim pageTitle spacing, tweak notification banner copy and spacing, add an "Actions" column header, and make small table/markup formatting fixes.

These edits focus on content clarity and minor layout/markup improvements.