### PR TITLE
Add LA decision review views and route

### DIFF
--- a/app/routes/fsm/private_beta/v8-1/appeal-decision-expansion.js
+++ b/app/routes/fsm/private_beta/v8-1/appeal-decision-expansion.js
@@ -1,0 +1,22 @@
+module.exports = function (router) {
+
+router.get('/fsm/private_beta/v8-1/test_johnson1', function (req, res) {
+  res.send('Route works!');
+});
+
+
+router.post('/fsm/private_beta/v8-1/appeal-decision/johnson1', function (req, res) {
+  const decision = req.session.data['decision'];
+
+  if (decision === 'approve') {
+    res.redirect('/fsm/private_beta/v8-1/LA/la-manage/decision/records/approve-johnson1');
+  } else if (decision === 'decline') {
+    res.redirect('/fsm/private_beta/v8-1/LA/la-manage/decision/records/decline-johnson1');
+  } else if (decision === 'pending') {
+    res.redirect('/fsm/private_beta/v8-1/LA/la-manage/decision/records/requestmore-johnson1');
+  } else {
+    res.redirect('/fsm/private_beta/v8-1/appeal-decision');
+  }
+});
+}
+

--- a/app/views/FSM/Private_beta/v8-1/LA/dashboard.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/dashboard.html
@@ -41,7 +41,7 @@
         <div class="dfe-card-container">
           <h2 class="govuk-heading-m">
             <a class="govuk-link govuk-link--no-visited-state dfe-card-link--header"
-              href="la-manage/decision/pending-list">Review applications</a>
+              href="la-manage/decision/review/applications.html">Review applications</a>
           </h2>
           <p>Review evidence provided for pending applications.</p>
         </div>

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/records/evidence/evidence-45678765.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/records/evidence/evidence-45678765.html
@@ -1,0 +1,63 @@
+{% extends "layouts/FSM/v8-1/layout-dfe-lanav.html" %}
+{% set parentName="Alan Jones" %}
+{% set parentId="123456789" %}
+{% set reference="44455453" %}
+{% set pageName="Supporting evidence for " ~ parentName%}
+
+{% block pageTitle %}
+{{pageName}}
+{% endblock %}
+
+{% block pageHeader %}
+{{pageName}}
+{% endblock %}
+<!----fudged the code for the back link as it wouldnt work with the zoom function on the evidence-->
+{% block beforeContent %}
+ <!-- {{ govukBackLink({
+      text: "Back",
+      href: "javascript:window.history.back()"
+    }) }} -->
+{% endblock %}
+{% block content %}
+<div class="govuk-grid-row govuk-!-margin-bottom-5">
+  <div class="govuk-grid-column-full">
+
+    <h1 class="govuk-heading-l">
+      {{pageName}}
+    </h1>
+
+    <h2 class="govuk-caption-l">File 001.jpg</h2>
+
+    <div style="position: relative; display: inline-block;">
+      <img src="/public/images/evidence-examples/UCstatement-single.jpg" alt="Description of the image"
+        class="govuk-!-width-full" style="max-width: 400px; height: auto; cursor: zoom-in;" onclick="openModal();">
+
+      <!-- Modal for zoom -->
+      <div id="zoomModal"
+        style="display: none; position: fixed; z-index: 1000; left: 0; top: 0; width: 100%; height: 100%; overflow: auto; background-color: rgba(0,0,0,0.8); text-align: left;">
+        <span
+          style="position: absolute; top: 20px; right: 35px; color: white; font-size: 40px; font-weight: bold; cursor: pointer;"
+          onclick="closeModal();">&times;</span>
+        <style>
+          @media print {
+            #zoomModal {
+              display: none !important;
+            }
+          }
+        </style>
+        <img src="/public/images/evidence-examples/UCstatement-single.jpg" alt="Zoomed image"
+          style="margin: auto ; display: block; max-width: 200%; max-height: 200%;">
+      </div>
+    </div>
+    <script>
+      function openModal() {
+        document.getElementById('zoomModal').style.display = 'block';
+      }
+
+      function closeModal() {
+        document.getElementById('zoomModal').style.display = 'none';
+      }
+    </script>
+  </div>
+
+{% endblock %}

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/records/pending/pending_45678765.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/records/pending/pending_45678765.html
@@ -15,8 +15,6 @@ href: "javascript:window.history.back()"
 {% set nationalInsurance = "AB123456C" %}
 {% set parentId = "45678765a" %}
 {% set childName = "Jack Jones" %}
-{% set endDate = " " %}
-{% set policyLabel = "Evidence needed" %}
 {% set pageName = "Manage pupil record for " ~ childName %}
 {% set pageDescription %} View and manage the details of this pupil record.
 {% endset %}
@@ -28,7 +26,7 @@ href: "javascript:window.history.back()"
   <div class="govuk-grid-column-full">
     <div style="display: flex; justify-content: space-between; align-items: center;">
       <div>
-        <span class="govuk-caption-l">{{childId}}</span>
+        <span class="govuk-caption-l">45678765</span>
         <h1 class="govuk-heading-l" style="margin-bottom: 0;">{{childName}}</h1>
           </div>
             <div>
@@ -40,9 +38,11 @@ href: "javascript:window.history.back()"
               {
               text: "Export record as CSV"
               },
-
               {
-              href: "archive-87606576.html",
+              text: "Export record as PDF"
+              },
+              {
+              href: "archive-44455453.html",
               text: "Archive record"
               }
               ]
@@ -65,12 +65,12 @@ href: "javascript:window.history.back()"
           <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
-                  <strong class="govuk-tag govuk-tag--yellow" style="margin-left: 0px;">
-                    {{ policyLabel }}
+                  <strong class="govuk-tag govuk-tag--blue" style="margin-left: 0px;">
+                    Needs reviewing
                 </strong>
               </dt>
               <dd class="govuk-summary-list__value">
-The parent needs to provide additional evidence. Review the application when the evidence has been received.
+              This application is ready for you to review the evidence.
               </dd>
             </div>
             <div class="govuk-summary-list__row">
@@ -78,7 +78,6 @@ The parent needs to provide additional evidence. Review the application when the
                 End date
               </dt>
               <dd class="govuk-summary-list__value">
-                {{ endDate }}
               </dd>
             </div>
           </dl>
@@ -193,25 +192,33 @@ The parent needs to provide additional evidence. Review the application when the
     <h2 class="govuk-summary-card__title">
       Supporting evidence
     </h2>
-    <ul class="govuk-summary-card__actions">
+    <!-- <ul class="govuk-summary-card__actions">
       <li class="govuk-summary-card__action">
         <a class="govuk-link" href="#">Add evidence<span class="govuk-visually-hidden"> add supporting
             evidence</span></a>
       </li>
-      <!-- <li class="govuk-summary-card__action">
+      <li class="govuk-summary-card__action">
         <a class="govuk-link" href="#">Remove evidence<span class="govuk-visually-hidden"> </span></a>
-      </li> -->
-    </ul>
+      </li>
+    </ul> -->
   </div>
 
   <div class="govuk-summary-card__content">
     <dl class="govuk-summary-list">
-      <div class="govuk-summary-list__row">
+      <!-- <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Evidence type
+        </dt>
+        <dd class="govuk-summary-list__value">
+          UC statement
+        </dd>
+      </div> -->
+        <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           Date uploaded
         </dt>
         <dd class="govuk-summary-list__value">
-          <!-- 20 Sep 2023 -->
+          20 Sep 2023
         </dd>
       </div>
       <div class="govuk-summary-list__row">
@@ -219,7 +226,7 @@ The parent needs to provide additional evidence. Review the application when the
           Files
         </dt>
         <dd class="govuk-summary-list__value">
-          <!-- <a href="evidence.html">UC_statement_2023.pdf</a><br> -->
+          <a href="../../records/evidence/evidence-45678765.html">UC_statement_2023.pdf</a><br>
           <a href="#"> </a><br>
         </dd>
       </div>
@@ -228,16 +235,16 @@ The parent needs to provide additional evidence. Review the application when the
           Evidence status
         </dt>
         <dd class="govuk-summary-list__value">
-          <!-- <strong class="govuk-tag govuk-tag--green" style="margin-left: 0px;">
+          <strong class="govuk-tag govuk-tag--green" style="margin-left: 0px;">
             Evidence added
-          </strong> -->
+          </strong>
         </dd>
       </div>
   </div>
   </div>
 
   <!-- <div class="govuk-!-padding-bottom-3"></div> -->
-<!--
+
 <div style="height: 32px;"></div>
 <form method="post" action="/fsm/private_beta/v8-1/appeal-decision/johnson1">
 {{ govukRadios({
@@ -254,20 +261,16 @@ The parent needs to provide additional evidence. Review the application when the
   },
   items: [
     {
-      value: "approve",
-      text: "Approve application"
+      value: "approve targeted",
+      text: "Approve for targeted free school meals"
+    },
+    {
+      value: "approve expanded",
+      text: "Approve for expanded free school meals"
     },
     {
       value: "decline",
       text: "Decline application"
-    },
-    {
-      value: "pending",
-      text: "Request more evidence",
-
-      conditional: {
-        html: '<p class="govuk-body"></p>'
-      }
     }
   ]
 }) }}
@@ -279,7 +282,7 @@ The parent needs to provide additional evidence. Review the application when the
     </button>
     <a class="govuk-link" href="../pending-list.html">Return to review list</a>
   </div>
-</form> -->
+</form>
 
 {% endblock %}
 

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/review/applications-combined.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/review/applications-combined.html
@@ -1,0 +1,235 @@
+{% extends "layouts/FSM/v7-4/layout-dfe-schoolnav-noback.html" %}
+{% set applications = 6 %}
+{% set pageName = "Review " ~ applications ~ " applications" %}
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="moj-page-header-actions">
+      <div class="moj-page-header-actions__title">
+        <h1 class="govuk-heading-l">
+          {{ pageName }}
+          <!-- <span id="notifications" class="moj-notification-badge" style="white-space: nowrap; margin-left: 15px;"></span> -->
+        </h1>
+      </div>
+      <!-- </div> -->
+      <div class="moj-page-header-actions__actions">
+        <div class="moj-button-group moj-button-group--inline">
+          <div class="moj-button-menu" data-module="moj-button-menu" data-button-text="Record a decision"
+            data-button-classes="govuk-button" data-align-menu="right">
+            <a href="#" role="button" draggable="false"
+              class="govuk-button moj-button-menu__item govuk-button--secondary" data-module="govuk-button">
+              Finalise applications
+            </a>
+            <a href="#" role="button" draggable="false"
+              class="govuk-button moj-button-menu__item govuk-button--secondary" data-module="govuk-button">
+              Request a review
+            </a>
+            <a href="#" role="button" draggable="false"
+              class="govuk-button moj-button-menu__item govuk-button--secondary" data-module="govuk-button">
+              Archive applications
+            </a>
+          </div>
+        </div>
+      </div>
+      <div class="moj-page-header-actions__description">
+        <!-- <p class="govuk-body">You have {{ applications }} applications to review.</p> -->
+        <p class="govuk-body">You can review an individual application for a child or manage multiple records.</p>
+      </div>
+    </div>
+    <!-- </div> -->
+    <!-- <div class="govuk-width-container" style="background-color: #e0f3ff; padding: 1em; margin-top: 1em;">
+  <div class="moj-search">
+    <form action="#" method="post">
+      <div class="govuk-form-group">
+        <label class="govuk-label moj-search__label govuk-!-font-weight-bold" for="search">
+          Find a pupil
+        </label>
+        <div id="search-hint" class="govuk-hint moj-search__hint">
+          You can search by application reference number, parent or child's name or their date of birth
+        </div>
+        <input class="govuk-input moj-search__input" id="search" name="search" type="search" aria-describedby="search-hint">
+      </div>
+      <button type="submit" class="govuk-button moj-search__button" data-module="govuk-button">
+        Search
+      </button>
+    </form>
+  </div> -->
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-width-container  padding: 1em; margin-top: 1em;">
+          <div class="moj-search">
+            <form action="#" method="post">
+              <div class="govuk-form-group">
+                <label class="govuk-label govuk-!-font-weight-bold" for="search">
+                  Find a child
+                </label>
+                <div id="search-hint" class="govuk-hint">
+                  You can search by name, date of birth or National Insurance number
+                </div>
+
+                <div style="display: flex; gap: 10px; align-items: center; flex-wrap: wrap; margin-top: 5px;">
+                  <input class="govuk-input" id="search" name="search" type="search" aria-describedby="search-hint"
+                    style="flex: 1; min-width: 250px; margin-bottom: 0;">
+
+                  <button type="submit" class="govuk-button" data-module="govuk-button" style="margin-bottom: 0;">
+                    Search
+                  </button>
+
+                  <button type="button" class="govuk-button govuk-button--secondary" style="margin-bottom: 0;" onclick="
+        document.getElementById('search').value = '';
+        document.querySelectorAll('.appeal-row').forEach(r => r.style.display = '');
+      ">
+                    Clear search
+                  </button>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+        <div style="padding-bottom: 2em;"></div>
+      </div>
+      <!-- </div> -->
+
+
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <div class="govuk-!-padding-bottom-3"></div>
+          <table class="govuk-table" data-module="moj-multi-select" data-multi-select-checkbox="#select-all">
+            <thead class="govuk-table__head">
+              <tr class="govuk-table__row">
+                <th class="govuk-table__header" scope="col" id="select-all"></th>
+                <th class="govuk-table__header" scope="col">Reference</th>
+                <th class="govuk-table__header" scope="col">Parent or guardian</th>
+                <th class="govuk-table__header" scope="col">Child name</th>
+                <th class="govuk-table__header govuk-table__header--numeric" scope="col">Child date of birth</th>
+                <th class="govuk-table__header" scope="col">Decision</th>
+                <th class="govuk-table__header govuk-table__header--numeric" scope="col">Submission date</th>
+              </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+              <tr class="govuk-table__row govuk-table__row--selected">
+                <td class="govuk-table__cell">
+                  <div class="govuk-checkboxes__item govuk-checkboxes--small moj-multi-select__checkbox">
+                    <input type="checkbox" class="govuk-checkboxes__input" id="mountain-aconcagua-1">
+                    <label class="govuk-label govuk-checkboxes__label" for="mountain-aconcagua-1">
+                      <span class="govuk-visually-hidden">Select</span>
+                    </label>
+                  </div>
+                </td>
+                <td class="govuk-table__cell"><a href="../appeal_statuses/eligible" class="govuk-link">44455456</a></td>
+                <td class="govuk-table__cell">Jim Smith</td>
+                <td class="govuk-table__cell">Arthur Smith</td>
+                <td class="govuk-table__cell govuk-table__cell--numeric">18 Sep 2017</td>
+                <td class="govuk-table__cell">
+                  {{ govukTag({ text: "Finalise application", classes: "govuk-tag--green" }) }}
+                </td>
+                <td class="govuk-table__cell govuk-table__cell--numeric">25 Sep 2023</td>
+              </tr>
+              <tr class="govuk-table__row govuk-table__row--selected">
+                <td class="govuk-table__cell">
+                  <div class="govuk-checkboxes__item govuk-checkboxes--small moj-multi-select__checkbox">
+                    <input type="checkbox" class="govuk-checkboxes__input" id="mountain-aconcagua-2">
+                    <label class="govuk-label govuk-checkboxes__label" for="mountain-aconcagua-2">
+                      <span class="govuk-visually-hidden">Select</span>
+                    </label>
+                  </div>
+                </td>
+                <td class="govuk-table__cell"><a href="../apply/entitled-rachel" class="govuk-link">44455453</a></td>
+                <td class="govuk-table__cell">Eden Tesfay</td>
+                <td class="govuk-table__cell">Rachel Tesfay</td>
+                <td class="govuk-table__cell govuk-table__cell--numeric">18 Sep 2017</td>
+                <td class="govuk-table__cell">
+                  {{ govukTag({ text: "Finalise application", classes: "govuk-tag--green" }) }}
+                </td>
+                <td class="govuk-table__cell govuk-table__cell--numeric">26 Sep 2023</td>
+              </tr>
+              <tr class="govuk-table__row govuk-table__row--selected">
+                <td class="govuk-table__cell">
+                  <div class="govuk-checkboxes__item govuk-checkboxes--small moj-multi-select__checkbox">
+                    <input type="checkbox" class="govuk-checkboxes__input" id="mountain-aconcagua-3">
+                    <label class="govuk-label govuk-checkboxes__label" for="mountain-aconcagua-3">
+                      <span class="govuk-visually-hidden">Select</span>
+                    </label>
+                  </div>
+                </td>
+                <td class="govuk-table__cell"><a href="../more-johnson1.html" class="govuk-link">44455453</a></td>
+                <td class="govuk-table__cell">Alex Johnson</td>
+                <td class="govuk-table__cell">Emily Johnson</td>
+                <td class="govuk-table__cell govuk-table__cell--numeric">18 Sep 2017</td>
+                <td class="govuk-table__cell">
+                  {{ govukTag({ text: "More evidence needed", classes: "govuk-tag--yellow" }) }}
+                </td>
+                <td class="govuk-table__cell govuk-table__cell--numeric">27 Sep 2023</td>
+              </tr>
+              <tr class="govuk-table__row govuk-table__row--selected">
+                <td class="govuk-table__cell">
+                  <div class="govuk-checkboxes__item govuk-checkboxes--small moj-multi-select__checkbox">
+                    <input type="checkbox" class="govuk-checkboxes__input" id="mountain-aconcagua-4">
+                    <label class="govuk-label govuk-checkboxes__label" for="mountain-aconcagua-4">
+                      <span class="govuk-visually-hidden">Select</span>
+                    </label>
+                  </div>
+                </td>
+                <td class="govuk-table__cell"><a href="../appeal_statuses/emailed-not-eligible"
+                    class="govuk-link">44455457</a></td>
+                <td class="govuk-table__cell">Trevor Sinclair</td>
+                <td class="govuk-table__cell">Polly Sinclair</td>
+                <td class="govuk-table__cell govuk-table__cell--numeric">18 Sep 2017</td>
+                <td class="govuk-table__cell">
+                  {{ govukTag({ text: "Waiting on review", classes: "govuk-tag--orange" }) }}
+                </td>
+                <td class="govuk-table__cell govuk-table__cell--numeric">28 Sep 2023</td>
+              </tr>
+              <tr class="govuk-table__row govuk-table__row--selected">
+                <td class="govuk-table__cell">
+                  <div class="govuk-checkboxes__item govuk-checkboxes--small moj-multi-select__checkbox">
+                    <input type="checkbox" class="govuk-checkboxes__input" id="mountain-ben-nevis-1">
+                    <label class="govuk-label govuk-checkboxes__label" for="mountain-ben-nevis-1">
+                      <span class="govuk-visually-hidden">Select</span>
+                    </label>
+                  </div>
+                </td>
+                <td class="govuk-table__cell"><a href="../appeal_statuses/emailed-not-eligible"
+                    class="govuk-link">55566789</a></td>
+                <td class="govuk-table__cell">Sophie Turner</td>
+                <td class="govuk-table__cell">Lucas Turner</td>
+                <td class="govuk-table__cell govuk-table__cell--numeric">12 Mar 2016</td>
+                <td class="govuk-table__cell">
+                  {{ govukTag({ text: "Review overdue", classes: "govuk-tag--pink" }) }}
+                </td>
+                <td class="govuk-table__cell govuk-table__cell--numeric">30 Sep 2023</td>
+              </tr>
+              <tr class="govuk-table__row govuk-table__row--selected">
+                <td class="govuk-table__cell">
+                  <div class="govuk-checkboxes__item govuk-checkboxes--small moj-multi-select__checkbox">
+                    <input type="checkbox" class="govuk-checkboxes__input" id="mountain-ben-nevis-2">
+                    <label class="govuk-label govuk-checkboxes__label" for="mountain-ben-nevis-2">
+                      <span class="govuk-visually-hidden">Select</span>
+                    </label>
+                  </div>
+                </td>
+                <td class="govuk-table__cell"><a href="../appeal_statuses/emailed-not-eligible"
+                    class="govuk-link">55566789</a></td>
+                <td class="govuk-table__cell">James Carter</td>
+                <td class="govuk-table__cell">Olivia Carter</td>
+                <td class="govuk-table__cell govuk-table__cell--numeric">12 Mar 2016</td>
+                <td class="govuk-table__cell">
+                  {{ govukTag({ text: "Declined", classes: "govuk-tag--red" }) }}
+                </td>
+                <td class="govuk-table__cell govuk-table__cell--numeric">30 Sep 2023</td>
+              </tr>
+            </tbody>
+          </table>
+          {% endblock %}
+
+          {% block scripts %}
+          {{ super() }}
+          <script>
+            document.addEventListener('DOMContentLoaded', function () {
+              var table = document.querySelector('.govuk-table tbody');
+              var count = table ? table.querySelectorAll('tr').length : 0;
+              document.getElementById('notifications').textContent = count;
+            });
+          </script>
+          {% endblock %}

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/review/applications.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/review/applications.html
@@ -1,0 +1,275 @@
+{% extends "layouts/FSM/v8-1/layout-dfe-schoolnav.html" %}
+{% set applications = 29 %}
+{% set pageName = "Review " ~ applications ~ " applications" %}
+
+
+{% block content %}
+
+<div class="govuk-grid-row">
+   <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l" id="pending-applications-heading">
+      <span id="row-count"></span> {{ pageName }}
+    </h1>
+    <!-- <script>
+      document.addEventListener('DOMContentLoaded', function() {
+      var table = document.querySelector('.govuk-table tbody');
+      var rowCount = table ? table.querySelectorAll('tr').length : 0;
+      document.getElementById('row-count').textContent = rowCount + 15;
+      });
+    </script> -->
+
+      <!-- <span id="notifications" class="moj-notification-badge" style="white-space: nowrap; margin-left: 15px;">36</span> -->
+
+    </h1>
+    <div class="govuk-grid-column-two-thirds govuk-!-padding-0 padding: 1em; margin-top: 1em;">
+
+    <!-- style="background-color: #e0f3ff; padding: 1em; margin-top: 1em;"> -->
+<hr class="govuk-section-break govuk-section-break--s govuk-section-break">
+
+      <div class="moj-search">
+
+        <form action="#" method="post">
+
+          <div class="govuk-form-group">
+            <label class="govuk-label moj-search__label govuk-!-font-weight-bold" for="search">
+              Find a child
+            </label>
+
+            <div id="search-hint" class="govuk-hint moj-search__hint ">
+              You can search by name, date of birth, school or National Insurance number
+            </div>
+            <input class="govuk-input moj-search__input " id="search" name="search" type="search" aria-describedby="search-hint">
+          </div>
+          <button type="submit" class="govuk-button moj-search__button " data-module="govuk-button">
+            Search
+          </button>
+        </form>
+      </div>
+    </div>
+
+  </div>
+     <div class="govuk-grid-column-full">
+
+  <div style="padding-bottom: 2em;"></div>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+<hr class="govuk-section-break govuk-section-break--s govuk-section-break">
+    <div class="govuk-grid-column-full govuk-!-padding-0 padding: 1em; margin-top: 1em;">
+
+
+<table class="govuk-table" data-module="moj-sortable-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col" aria-sort="ascending">Reference</th>
+      <th class="govuk-table__header" scope="col" aria-sort="none">Parent or guardian</th>
+      <th class="govuk-table__header" scope="col" aria-sort="none">Parent or guardian <br>date of birth</th>
+      <th class="govuk-table__header" scope="col" aria-sort="none">Child name</th>
+      <th class="govuk-table__header" scope="col" aria-sort="none">School</th>
+      <th class="govuk-table__header" scope="col" aria-sort="none">Date submitted</th>
+       <th class="govuk-table__header" scope="col" aria-sort="none">Action required</th>
+        <th class="govuk-table__header" scope="col"></th>
+
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"><a href="../review/needs-review/pending_44455453.html" class="govuk-link">44455453</a></td>
+      <td class="govuk-table__cell">Alex Johnson <br></td>
+      <td class="govuk-table__cell">15 Mar 1980</td>
+      <td class="govuk-table__cell">Emily Johnson</td>
+      <td class="govuk-table__cell">Hilltop Elementary</td>
+      <td class="govuk-table__cell">20 Sep 2012</td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">Needs reviewing</strong></td>
+      <!-- <td class="govuk-table__cell">
+        <a href="../decision/records/pending_44455453.html" class="govuk-link">Review</a>
+      </td> -->
+    </tr>
+
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"><a href="../review/needs-review/" class="govuk-link">44455454</a></td>
+      <td class="govuk-table__cell">Warren Sutton</td>
+      <td class="govuk-table__cell">18 Sep 1978</td>
+      <td class="govuk-table__cell">Lisa Sutton</td>
+      <td class="govuk-table__cell">St Mary's</td>
+            <td class="govuk-table__cell">25 Sep 2023</td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">Needs reviewing</strong></td>
+
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"><a href="../records/evidence-needed/evidence-needed-45678765.html" class="govuk-link">45678765</a></td>
+      <td class="govuk-table__cell">Alan Jones</td>
+      <td class="govuk-table__cell">18 Sep 1978</td>
+      <td class="govuk-table__cell">Jack Jones</td>
+      <td class="govuk-table__cell">Greenfield Primary</td>
+      <td class="govuk-table__cell">25 Sep 2023</td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">Evidence needed</strong></td>
+
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"><a href="../records/approved" class="govuk-link">44455456</a></td>
+      <td class="govuk-table__cell">Rachel Evans</td>
+      <td class="govuk-table__cell">22 Jul 1982</td>
+      <td class="govuk-table__cell">Mia Evans</td>
+      <td class="govuk-table__cell">Riverside Academy</td>
+      <td class="govuk-table__cell">25 Sep 2023</td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">Evidence needed</strong></td>
+
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"><a href="../records/approved" class="govuk-link">44455457</a></td>
+      <td class="govuk-table__cell">Jennifer Langley</td>
+      <td class="govuk-table__cell">18 Sep 1978</td>
+      <td class="govuk-table__cell">Tilly Langley</td>
+      <td class="govuk-table__cell">Oakwood School</td>
+      <td class="govuk-table__cell">25 Sep 2023</td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">Needs reviewing</strong></td>
+
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"><a href="../records/approved" class="govuk-link">44455458</a></td>
+      <td class="govuk-table__cell">Susan Francis</td>
+      <td class="govuk-table__cell">18 Sep 1978</td>
+      <td class="govuk-table__cell">Noah Francis</td>
+      <td class="govuk-table__cell">Maple Grove</td>
+      <td class="govuk-table__cell">25 Sep 2023</td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">Needs reviewing</strong></td>
+
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"><a href="../records/approved" class="govuk-link">44455459</a></td>
+      <td class="govuk-table__cell">John Smith</td>
+      <td class="govuk-table__cell">18 Sep 1978</td>
+      <td class="govuk-table__cell">Jo Smith</td>
+      <td class="govuk-table__cell">Sunnydale High</td>
+      <td class="govuk-table__cell">25 Sep 2023</td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">Needs reviewing</strong></td>
+
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"><a href="../records/new-appeal" class="govuk-link">44455460</a></td>
+      <td class="govuk-table__cell">Rachel Evans</td>
+      <td class="govuk-table__cell">22 Jul 1982</td>
+      <td class="govuk-table__cell">Mia Evans</td>
+      <td class="govuk-table__cell">Willow Park</td>
+       <td class="govuk-table__cell">25 Sep 2023</td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">Evidence needed</strong></td>
+
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"><a href="../records/approved" class="govuk-link">44455461</a></td>
+      <td class="govuk-table__cell">Warren Sutton</td>
+      <td class="govuk-table__cell">18 Sep 1978</td>
+      <td class="govuk-table__cell">Lisa Sutton</td>
+      <td class="govuk-table__cell">Elm Tree Primary</td>
+      <td class="govuk-table__cell">25 Sep 2023</td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">Needs reviewing</strong></td>
+
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"><a href="../records/approved" class="govuk-link">44455462</a></td>
+      <td class="govuk-table__cell">Alan Jones</td>
+      <td class="govuk-table__cell">18 Sep 1978</td>
+      <td class="govuk-table__cell">Jack Jones</td>
+      <td class="govuk-table__cell">Cedar Hill School</td>
+      <td class="govuk-table__cell">25 Sep 2023</td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">Needs reviewing</strong></td>
+
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"><a href="../records/approved" class="govuk-link">44455463</a></td>
+      <td class="govuk-table__cell">Rachel Evans</td>
+      <td class="govuk-table__cell">22 Jul 1982</td>
+      <td class="govuk-table__cell">Mia Evans</td>
+      <td class="govuk-table__cell">Lakeside Academy</td>
+      <td class="govuk-table__cell">25 Sep 2023</td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">Evidence needed</strong></td>
+
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"><a href="../records/approved" class="govuk-link">44455464</a></td>
+      <td class="govuk-table__cell">Jennifer Langley</td>
+      <td class="govuk-table__cell">18 Sep 1978</td>
+      <td class="govuk-table__cell">Tilly Langley</td>
+      <td class="govuk-table__cell">Birchwood School</td>
+      <td class="govuk-table__cell">25 Sep 2023</td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">Evidence needed</strong></td>
+
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"><a href="../records/approved" class="govuk-link">44455465</a></td>
+      <td class="govuk-table__cell">Susan Francis</td>
+      <td class="govuk-table__cell">18 Sep 1978</td>
+      <td class="govuk-table__cell">Noah Francis</td>
+      <td class="govuk-table__cell">Redwood Academy</td>
+       <td class="govuk-table__cell">25 Sep 2023</td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">Evidence needed</strong></td>
+
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"><a href="../records/approved" class="govuk-link">44455466</a></td>
+      <td class="govuk-table__cell">John Smith</td>
+      <td class="govuk-table__cell">18 Sep 1978</td>
+      <td class="govuk-table__cell">Jo Smith</td>
+      <td class="govuk-table__cell">Pinecrest High</td>
+            <td class="govuk-table__cell">25 Sep 2023</td>
+      <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--blue">Needs reviewing</strong></td>
+
+    </tr>
+  </tbody>
+</table>
+
+<!-------pagination------->
+<div style="display: flex; justify-content: center; width: 100%;">
+  <div style="width: fit-content;">
+
+{{ govukPagination({
+
+  next: {
+    href: "#"
+  },
+  items: [
+    {
+      number: 1,
+         current: true,
+      href: "#"
+    },
+    {
+      ellipsis: true
+    },
+    {
+      number: 6,
+      href: "#"
+    },
+    {
+      number: 7,
+      href: "#"
+    },
+    {
+      number: 8,
+      href: "#"
+    },
+    {
+      ellipsis: true
+    },
+    {
+      number: 12,
+      href: "#"
+    }
+  ]
+}) }}
+  </div>
+</div>
+
+
+
+
+
+
+    </div>
+
+
+  </div>
+</div>
+
+{% endblock %}
+

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/review/needs-review/approved/approve-johnson1.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/review/needs-review/approved/approve-johnson1.html
@@ -1,0 +1,42 @@
+{% extends "layouts/FSM/v8-1/layout-dfe-schoolnav.html" %}
+{% set pageName="Approve application?" %}
+{% block content %}
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Approve this application?</h1>
+        <p class="govuk-body">
+          The parent or guardian will receive support towards free school meals if you approve this application. </p>
+      </div>
+    </div>
+  </div>
+
+
+<div class="govuk-!-padding-bottom-3"></div>
+{{ govukButton({
+text: "Approve now",
+href: 'eligibility-confirmed'
+}) }}
+
+{{ govukButton({
+text: "Review later",
+classes: "govuk-button--secondary",
+href: 'pending_johnson1'
+}) }}
+<!--
+<p class="govuk-body">
+  <a href="../pending-list" class="govuk-link">Review another application</a>
+</p> -->
+
+
+<div class="govuk-!-padding-bottom-3"></div>
+
+</div>
+</div>
+
+{% endblock %}
+
+{% block pageScripts %}
+<script type="text/javascript" src="/public/javascripts/moj/all.js"></script>
+{% endblock %}

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/review/needs-review/approved/eligibility-confirmed.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/review/needs-review/approved/eligibility-confirmed.html
@@ -1,0 +1,63 @@
+{% extends "layouts/FSM/v8-1/layout-dfe-schoolnav.html" %}
+{% set pageName="Application approved" %}
+{% set Date = "22 Sep 2025" %}
+
+{% block content %}
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <div class="govuk-width-container">
+      <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-panel govuk-panel--confirmation">
+              <h1 class="govuk-panel__title">
+                Application approved
+              </h1>
+
+              <div class="govuk-panel__body">
+                Application reference number<br><strong>44455453</strong>
+              </div>
+              <br>
+                <div class="govuk-panel__body">
+                Requested on {{Date}}
+              </div>
+            </div>
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break">
+
+            <h2 class="govuk-heading-m">What happens next</h2>
+            <p class="govuk-body">
+              The school will receive a notification to finalise the application and add the details to their
+              Management Information System (MIS). </p>
+            <!-- <p class="govuk-body">
+               If you need to find the application again, you can <a href="search">search all records</a>. -->
+
+          </div>
+        </div>
+        <br>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body">
+              <a class="govuk-link" href="../../applications.html"> Review more applications.</a>
+            </p>
+<!--
+<hr class="govuk-section-break govuk-section-break--xl govuk-section-break">
+         <h2 class="govuk-heading-s">We want to get your feedback</h2>
+
+            <p class="govuk-body">
+              <a href="#" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)
+            </p> -->
+            </div>
+      </main>
+    </div>
+  </div>
+
+  <!-- <div class="govuk-button-group"> -->
+  <!-- <a class="govuk-link" href="../pending-list">Review another application</a> -->
+  <!-- <a class="govuk-link" href="../../../dashboard">Return to dashboard</a> -->
+</div>
+
+
+{% endblock %}

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/review/needs-review/declined/decline-johnson1.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/review/needs-review/declined/decline-johnson1.html
@@ -1,0 +1,65 @@
+{% extends "layouts/FSM/v8-1/layout-dfe-lanav.html" %}
+{% set pageName="Decline the application?" %}
+{% block content %}
+
+<div class="govuk-width-container">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">{{pageName}}</h1>
+
+            <div class="govuk-form-group">
+                <h2 class="govuk-label-wrapper">
+                    <label class="govuk-label govuk-label--m" for="more-detail">
+                        Give a reason for declining the application
+                    </label>
+                </h2>
+                <div id="more-detail-hint" class="govuk-hint">
+                    Do not include personal or financial information like the child's name, parent's National Insurance
+                    number or statement details.  <!--<br><br>Parent and guardians can request access to the reasons for declining the application, for example as
+                    a Freedom of Information request. -->
+                </div>
+                <textarea class="govuk-textarea" id="more-detail" name="moreDetail" rows="5"
+                    aria-describedby="more-detail-hint"></textarea>
+            </div>
+            <!-- <p class="govuk-body">
+Parent and guardians can request access to the reasons for declining the application, for example as a Freedom of Information request.
+</p> -->
+
+            <div class="govuk-warning-text">
+                <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                <strong class="govuk-warning-text__text">
+                    <span class="govuk-visually-hidden">Warning</span>
+                    Parents and guardians can request access to the reason for declining their application as
+                    part of a Freedom of Information request.
+                </strong>
+            </div>
+
+<div class="govuk-inset-text">
+    If you decline this application, the parent or guardian will have to start a new application. If
+    you are unsure, return to the record and request more evidence.
+</div>
+
+<div class="govuk-!-padding-bottom-3"></div>
+
+
+
+{{ govukButton({
+text: "Decline now",
+href: 'eligibility-declined'
+}) }}
+
+{{ govukButton({
+text: "Return to record",
+classes: "govuk-button--secondary",
+href: 'pending_johnson1'
+}) }}
+
+<div class="govuk-!-padding-bottom-3"></div>
+</div>
+
+
+{% endblock %}
+
+{% block pageScripts %}
+<script type="text/javascript" src="/public/javascripts/moj/all.js"></script>
+{% endblock %}

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/review/needs-review/declined/eligibility-declined.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/review/needs-review/declined/eligibility-declined.html
@@ -1,0 +1,82 @@
+{% extends "layouts/FSM/v7-4/layout-dfe-lanav-noback.html" %}
+{% set Date = "22 Sep 2025" %}
+
+{% set pageName="Application declined" %}
+
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <div class="govuk-width-container">
+      <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-panel govuk-panel--confirmation">
+              <h1 class="govuk-panel__title">
+                Application declined
+              </h1>
+              <div class="govuk-panel__body">
+                Application reference number<br><strong>44455453</strong>
+              </div>
+              <br>
+                <div class="govuk-panel__body">
+                Declined on {{Date}}
+              </div>
+            </div>
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break">
+
+            <h2 class="govuk-heading-m">What happens next</h2>
+            <p class="govuk-body">
+              The school will receive a notification that the child is not eligible after your review. </p>
+            <!-- <p class="govuk-body">
+               If you need to find the application again, you can <a href="search">search all records</a>. -->
+
+          </div>
+        </div>
+        <br>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body">
+              <a class="govuk-link" href="../../applications.html"> Review more applications.</a>
+            </p>
+
+<hr class="govuk-section-break govuk-section-break--xl govuk-section-break">
+         <h2 class="govuk-heading-s">We want to get your feedback</h2>
+
+            <p class="govuk-body">
+              <a href="#" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)
+            </p>
+            </div>
+      </main>
+    </div>
+  </div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+      </div>
+
+    </div>
+
+
+  </div>
+</div>
+
+{% endblock %}
+
+{% block pageScripts %}
+<script type="text/javascript" src="/public/javascripts/moj/all.js"></script>
+{% endblock %}

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/review/needs-review/evidence/evidence.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/review/needs-review/evidence/evidence.html
@@ -1,0 +1,63 @@
+{% extends "layouts/FSM/v8-1/layout-dfe-lanav.html" %}
+{% set parentName="Alex Johnson" %}
+{% set parentId="123456789" %}
+{% set reference="44455453" %}
+{% set pageName="Supporting evidence for " ~ parentName%}
+
+{% block pageTitle %}
+{{pageName}}
+{% endblock %}
+
+{% block pageHeader %}
+{{pageName}}
+{% endblock %}
+<!----fudged the code for the back link as it wouldnt work with the zoom function on the evidence-->
+{% block beforeContent %}
+ {{ govukBackLink({
+      text: "Back",
+      href: "javascript:window.history.back()"
+    }) }}
+{% endblock %}
+{% block content %}
+<div class="govuk-grid-row govuk-!-margin-bottom-5">
+  <div class="govuk-grid-column-full">
+
+    <h1 class="govuk-heading-l">
+      {{pageName}}
+    </h1>
+
+    <h2 class="govuk-caption-l">File 001.jpg</h2>
+
+    <div style="position: relative; display: inline-block;">
+      <img src="/public/images/evidence-examples/UCstatement-single.jpg" alt="Description of the image"
+        class="govuk-!-width-full" style="max-width: 400px; height: auto; cursor: zoom-in;" onclick="openModal();">
+
+      <!-- Modal for zoom -->
+      <div id="zoomModal"
+        style="display: none; position: fixed; z-index: 1000; left: 0; top: 0; width: 100%; height: 100%; overflow: auto; background-color: rgba(0,0,0,0.8); text-align: left;">
+        <span
+          style="position: absolute; top: 20px; right: 35px; color: white; font-size: 40px; font-weight: bold; cursor: pointer;"
+          onclick="closeModal();">&times;</span>
+        <style>
+          @media print {
+            #zoomModal {
+              display: none !important;
+            }
+          }
+        </style>
+        <img src="/public/images/evidence-examples/UCstatement-single.jpg" alt="Zoomed image"
+          style="margin: auto ; display: block; max-width: 200%; max-height: 200%;">
+      </div>
+    </div>
+    <script>
+      function openModal() {
+        document.getElementById('zoomModal').style.display = 'block';
+      }
+
+      function closeModal() {
+        document.getElementById('zoomModal').style.display = 'none';
+      }
+    </script>
+  </div>
+
+{% endblock %}

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/review/needs-review/pending_44455453.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/review/needs-review/pending_44455453.html
@@ -1,22 +1,20 @@
-{% extends "layouts/FSM/v8-1/layout-dfe-lanav.html" %}
+{% extends "layouts/FSM/v8-1/layout-dfe-schoolnav.html" %}
 {% block backLink %}
 {{ govukBackLink({
 text: "Back",
 href: "javascript:window.history.back()"
 }) }}
 {% endblock %}
-{% set childId = "45678765" %}
-{% set childDOB = "10 Jun 2018" %}
-{% set schoolName = "Springfield Primary" %}
+{% set childId = "44455453" %}
+{% set childDOB = "22 Sep 2012" %}
+{% set schoolName = "Hilltop Elementary" %}
 {% set schoolAddress = "Manchester, M25 1QA" %}
 {% set parentDOB = "15 Mar 1980" %}
-{% set parentName = "Alan Jones" %}
-{% set email = "alan.jones@example.com" %}
+{% set parentName = "Alex Johnson" %}
+{% set email = "alex.johnson@example.com" %}
 {% set nationalInsurance = "AB123456C" %}
-{% set parentId = "45678765a" %}
-{% set childName = "Jack Jones" %}
-{% set endDate = " " %}
-{% set policyLabel = "Evidence needed" %}
+{% set parentId = "44455454A" %}
+{% set childName = "Emily Johnson" %}
 {% set pageName = "Manage pupil record for " ~ childName %}
 {% set pageDescription %} View and manage the details of this pupil record.
 {% endset %}
@@ -28,7 +26,7 @@ href: "javascript:window.history.back()"
   <div class="govuk-grid-column-full">
     <div style="display: flex; justify-content: space-between; align-items: center;">
       <div>
-        <span class="govuk-caption-l">{{childId}}</span>
+        <span class="govuk-caption-l">44455453</span>
         <h1 class="govuk-heading-l" style="margin-bottom: 0;">{{childName}}</h1>
           </div>
             <div>
@@ -40,9 +38,11 @@ href: "javascript:window.history.back()"
               {
               text: "Export record as CSV"
               },
-
               {
-              href: "archive-87606576.html",
+              text: "Export record as PDF"
+              },
+              {
+              href: "archive-44455453.html",
               text: "Archive record"
               }
               ]
@@ -65,12 +65,12 @@ href: "javascript:window.history.back()"
           <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
-                  <strong class="govuk-tag govuk-tag--yellow" style="margin-left: 0px;">
-                    {{ policyLabel }}
+                  <strong class="govuk-tag govuk-tag--blue" style="margin-left: 0px;">
+                    Ready for review
                 </strong>
               </dt>
               <dd class="govuk-summary-list__value">
-The parent needs to provide additional evidence. Review the application when the evidence has been received.
+              This application is ready for you to review the evidence.
               </dd>
             </div>
             <div class="govuk-summary-list__row">
@@ -78,7 +78,8 @@ The parent needs to provide additional evidence. Review the application when the
                 End date
               </dt>
               <dd class="govuk-summary-list__value">
-                {{ endDate }}
+                <!-- The end date will updated when a decision is made or more evidence is requested. -->
+                 31 Aug 2026
               </dd>
             </div>
           </dl>
@@ -193,25 +194,33 @@ The parent needs to provide additional evidence. Review the application when the
     <h2 class="govuk-summary-card__title">
       Supporting evidence
     </h2>
-    <ul class="govuk-summary-card__actions">
+    <!-- <ul class="govuk-summary-card__actions">
       <li class="govuk-summary-card__action">
         <a class="govuk-link" href="#">Add evidence<span class="govuk-visually-hidden"> add supporting
             evidence</span></a>
       </li>
-      <!-- <li class="govuk-summary-card__action">
+      <li class="govuk-summary-card__action">
         <a class="govuk-link" href="#">Remove evidence<span class="govuk-visually-hidden"> </span></a>
-      </li> -->
-    </ul>
+      </li>
+    </ul> -->
   </div>
 
   <div class="govuk-summary-card__content">
     <dl class="govuk-summary-list">
+      <!-- <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Evidence type
+        </dt>
+        <dd class="govuk-summary-list__value">
+          UC statement
+        </dd>
+      </div> -->
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           Date uploaded
         </dt>
         <dd class="govuk-summary-list__value">
-          <!-- 20 Sep 2023 -->
+          20 Apr 2026
         </dd>
       </div>
       <div class="govuk-summary-list__row">
@@ -219,7 +228,7 @@ The parent needs to provide additional evidence. Review the application when the
           Files
         </dt>
         <dd class="govuk-summary-list__value">
-          <!-- <a href="evidence.html">UC_statement_2023.pdf</a><br> -->
+          <a href="evidence.html">UC_statement_2023.pdf</a><br>
           <a href="#"> </a><br>
         </dd>
       </div>
@@ -228,16 +237,16 @@ The parent needs to provide additional evidence. Review the application when the
           Evidence status
         </dt>
         <dd class="govuk-summary-list__value">
-          <!-- <strong class="govuk-tag govuk-tag--green" style="margin-left: 0px;">
+          <strong class="govuk-tag govuk-tag--green" style="margin-left: 0px;">
             Evidence added
-          </strong> -->
+          </strong>
         </dd>
       </div>
   </div>
   </div>
 
   <!-- <div class="govuk-!-padding-bottom-3"></div> -->
-<!--
+
 <div style="height: 32px;"></div>
 <form method="post" action="/fsm/private_beta/v8-1/appeal-decision/johnson1">
 {{ govukRadios({
@@ -274,12 +283,23 @@ The parent needs to provide additional evidence. Review the application when the
 
 
   <div class="govuk-button-group">
+<!--
     <button type="submit" class="govuk-button" data-module="govuk-button">
       Save and continue
-    </button>
+    </button> -->
+
+<button type="submit" class="govuk-button" data-module="govuk-button">
+  Save and continue
+</button>
+    <!-- <a href="request-more/requestmore-johnson1.html"
+   class="govuk-button"
+   data-module="govuk-button"
+   role="button">
+   Save and continue
+</a> -->
     <a class="govuk-link" href="../pending-list.html">Return to review list</a>
   </div>
-</form> -->
+</form>
 
 {% endblock %}
 

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/review/needs-review/request-more/eligibility-requested.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/review/needs-review/request-more/eligibility-requested.html
@@ -1,0 +1,85 @@
+{% extends "layouts/FSM/v7-4/layout-dfe-lanav-noback.html" %}
+{% set Date = "22 Sep 2025" %}
+{% set pageName="More evidence requested" %}
+
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="govuk-width-container">
+      <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-panel govuk-panel--confirmation">
+              <h1 class="govuk-panel__title">
+{{pageName}}              </h1>
+              <div class="govuk-panel__body">
+                Application reference number<br><strong>44455453</strong>
+              </div>
+              <br>
+                 <br>
+                <div class="govuk-panel__body">
+                Requested on {{Date}}
+              </div>
+                   <!-- <div class="govuk-panel__body">
+                Date requested<br><strong>{{Date}}</strong>
+              </div> -->
+            </div>
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break">
+
+            <h2 class="govuk-heading-m">What happens next</h2>
+            <p class="govuk-body">
+              The school will receive a notification that the review needs more evidence to support the application. <br><br>
+            They need to upload the evidence to the pupil record or send it directly to you by email.</p>
+            <!-- <p class="govuk-body">
+               If you need to find the application again, you can <a href="search">search all records</a>. -->
+
+          </div>
+        </div>
+        <br>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body">
+              <a class="govuk-link" href="../../applications.html">Review more applications.</a>
+            </p>
+
+<!-- <hr class="govuk-section-break govuk-section-break--xl govuk-section-break">
+         <h2 class="govuk-heading-s">We want to get your feedback</h2>
+
+            <p class="govuk-body">
+              <a href="#" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)
+            </p> -->
+            </div>
+      </main>
+    </div>
+  </div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+      </div>
+
+    </div>
+
+
+  </div>
+</div>
+
+{% endblock %}
+
+{% block pageScripts %}
+<script type="text/javascript" src="/public/javascripts/moj/all.js"></script>
+{% endblock %}

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/review/needs-review/request-more/requestmore-johnson1.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/review/needs-review/request-more/requestmore-johnson1.html
@@ -1,0 +1,68 @@
+{% extends "layouts/FSM/v8-1/layout-dfe-lanav.html" %}
+{% set parentName = "Alex Johnson" %}
+{% set pageName="Request more evidence from " ~ parentName %}
+
+{% block content %}
+
+<div class="govuk-width-container">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">{{pageName}}</h1>
+
+
+            <div class="govuk-form-group">
+                <h2 class="govuk-label-wrapper">
+                    <label class="govuk-label govuk-label--m" for="more-detail">
+                        Give a reason for requesting more evidence
+                    </label>
+                </h2>
+                 <div id="more-detail-hint" class="govuk-hint">
+                    Do not include personal or financial information like the child's name, parent's National Insurance
+                    number or statement details.
+                </div>
+                <textarea class="govuk-textarea" id="more-detail" name="moreDetail" rows="5"
+                    aria-describedby="more-detail-hint"></textarea>
+            </div>
+
+
+            <div class="govuk-warning-text">
+                <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                <strong class="govuk-warning-text__text">
+                    <span class="govuk-visually-hidden">Warning</span>
+                    Parents and guardians can request access to the request for more evidence for their application as
+                    part of a Freedom of Information request.
+                </strong>
+            </div>
+
+<!-- <div class="govuk-inset-text"> If you request more evidence, the parent or guardian will have to provide additional information to their school. -->
+<!-- </div> -->
+
+
+        </div>
+    </div>
+</div>
+
+<div class="govuk-!-padding-bottom-3"></div>
+
+
+{{ govukButton({
+text: "Submit request",
+href: 'eligibility-requested'
+}) }}
+
+{{ govukButton({
+text: "Return to record",
+classes: "govuk-button--secondary",
+href: '../pending-list'
+}) }}
+
+<div class="govuk-!-padding-bottom-3"></div>
+
+</div>
+</div>
+
+{% endblock %}
+
+{% block pageScripts %}
+<script type="text/javascript" src="/public/javascripts/moj/all.js"></script>
+{% endblock %}

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/report/search.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/report/search.html
@@ -52,7 +52,7 @@
                           <!-- <th scope="col" class="govuk-table__header" aria-sort="none">Parents National Insurance number</th> -->
                           <!-- <th scope="col" class="govuk-table__header" aria-sort="none">Parents dob</th> -->
                           <th scope="col" class="govuk-table__header" aria-sort="none">Child name</th>
-                          <th scope="col" class="govuk-table__header" aria-sort="none">Child dob</th>
+                          <th scope="col" class="govuk-table__header" aria-sort="none">Child date of birth</th>
                           <th scope="col" class="govuk-table__header" aria-sort="none">School</th>
                           <th scope="col" class="govuk-table__header" aria-sort="none">Date submitted</th>
                           <th scope="col" class="govuk-table__header" aria-sort="none">End date</th>

--- a/app/views/layouts/FSM/v8-1/layout-dfe-schoolnav.html
+++ b/app/views/layouts/FSM/v8-1/layout-dfe-schoolnav.html
@@ -1,15 +1,15 @@
-{# Imports #}
-{% from "node_modules/dfe-frontend/packages/components/header/macro.njk" import header %}
-{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
+{# 1 #}
+{% from 'node_modules/dfe-frontend/packages/components/header/macro.njk' import header %}
 
-{# Layout #}
+{# 2 #}
 {% extends "govuk-prototype-kit/layouts/govuk-branded.njk" %}
 {% set govukRebrand = true %}
 
-{# Single source of truth #}
-{% set VERSION = "v8-1" %}
-{% set ROOT = "/FSM/Private_beta/" + VERSION %}
+{# --- Single source of truth for this version --- #}
+{% set ROOT = "/FSM/Private_beta/v8-1" %}
 
+
+{# 3 #}
 {% block header %}
 <header class="govuk-header" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container">


### PR DESCRIPTION
Add Local Authority decision review workflow: new route (appeal-decision-expansion.js) to handle decision submissions and redirect based on session decision. Add multiple view templates for reviewing applications and records (applications, applications-combined, pending record, evidence viewer with zoom modal, evidence-needed/update, approved/declined flows and confirmation pages). Update dashboard link to point to the new review list and tweak sample data (parent/child details, reference IDs) and minor UI/content text in evidence-needed template. These changes implement the UI and routing needed to view supporting evidence and record/confirm decisions.