### PR TITLE
Add school codes, adjust tags, hide end date

### DIFF
--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/review/needs-review/pending_44455453.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/review/needs-review/pending_44455453.html
@@ -78,7 +78,7 @@ You can now review the application as the evidence has been received.           
               </dt>
               <dd class="govuk-summary-list__value">
                 <!-- The end date will updated when a decision is made or more evidence is requested. -->
-                 31 Aug 2026
+                 <!-- 31 Aug 2026 -->
               </dd>
             </div>
           </dl>

--- a/app/views/_includes/la/v8-1/la-table-rows.html
+++ b/app/views/_includes/la/v8-1/la-table-rows.html
@@ -5,7 +5,7 @@
     <td class="govuk-table__cell">Alex Johnson </td>
     <td class="govuk-table__cell">Emily Johnson</td>
     <td class="govuk-table__cell">{{ "2018-09-20" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Oakwood High</td>
+    <td class="govuk-table__cell">Oakwood High<br> 140459</td>
     <td class="govuk-table__cell">{{ "2020-09-25" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
     <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">Eligible expanded</strong>
@@ -18,7 +18,7 @@
     <td class="govuk-table__cell">Alex Jones</td>
     <td class="govuk-table__cell">Theo Jones</td>
     <td class="govuk-table__cell">{{ "2018-06-10" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Oakwood High</td>
+    <td class="govuk-table__cell">Oakwood High<br> 140459</td>
     <td class="govuk-table__cell">{{ "2018-09-20" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -30,7 +30,7 @@
     <td class="govuk-table__cell">Jessica Brown</td>
     <td class="govuk-table__cell">Rachel Brown</td>
     <td class="govuk-table__cell">{{ "2018-06-10" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Springfield Primary</td>
+    <td class="govuk-table__cell">Springfield Primary<br> 140460</td>
     <td class="govuk-table__cell">{{ "2018-09-20" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -42,7 +42,7 @@
     <td class="govuk-table__cell">Jennifer Langley</td>
     <td class="govuk-table__cell">Tilly Langley</td>
     <td class="govuk-table__cell">{{ "2017-12-03" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Oakfield Primary School</td>
+    <td class="govuk-table__cell">Oakfield Primary School<br> 140461  </td>
     <td class="govuk-table__cell">{{ "2023-09-25" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -54,11 +54,11 @@
     <td class="govuk-table__cell">Susan Francis</td>
     <td class="govuk-table__cell">Lincoln Francis</td>
     <td class="govuk-table__cell">{{ "2017-12-13" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Springfield Primary School</td>
+    <td class="govuk-table__cell">Springfield Primary School<br> 140460</td>
     <td class="govuk-table__cell">{{ "2023-09-25" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
-    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--red">Not eligible after review</strong></td>
+    <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--red">Not eligible</strong></td>
   </tr>
 
   <tr class="govuk-table__row matches-filters" data-school="Beacon View school" data-status="Application in review" data-phase="Primary" data-submission-date="2024-05-18">
@@ -66,7 +66,7 @@
     <td class="govuk-table__cell">Martin Gislason</td>
     <td class="govuk-table__cell">Aleysha Gislason</td>
     <td class="govuk-table__cell">{{ "2018-12-17" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Beacon View school</td>
+    <td class="govuk-table__cell">Beacon View school<br> 140463</td>
     <td class="govuk-table__cell">{{ "2024-05-18" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -78,7 +78,7 @@
     <td class="govuk-table__cell">Koby Cruickshank</td>
     <td class="govuk-table__cell">India Cruickshank</td>
     <td class="govuk-table__cell">{{ "2021-05-26" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Silver Birch Primary School</td>
+    <td class="govuk-table__cell">Silver Birch Primary School<br> 140464</td>
     <td class="govuk-table__cell">{{ "2024-05-27" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -90,7 +90,7 @@
     <td class="govuk-table__cell">Miller Kerluke</td>
     <td class="govuk-table__cell">Jan Kerluke</td>
     <td class="govuk-table__cell">{{ "2018-08-02" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Meadowpark school</td>
+    <td class="govuk-table__cell">Meadowpark school<br> 140465 </td>
     <td class="govuk-table__cell">{{ "2024-07-13" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -102,7 +102,7 @@
     <td class="govuk-table__cell">Jasen Romaguera</td>
     <td class="govuk-table__cell">Alfonso Romaguera</td>
     <td class="govuk-table__cell">{{ "2018-05-30" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Brookside Primary School</td>
+    <td class="govuk-table__cell">Brookside Primary School<br> 140466 </td>
     <td class="govuk-table__cell">{{ "2024-05-05" | govukDate("truncate") }}</td>
      <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -114,7 +114,7 @@
     <td class="govuk-table__cell">Zechariah Gottlieb</td>
     <td class="govuk-table__cell">Lettita Gottlieb</td>
     <td class="govuk-table__cell">{{ "2018-12-11" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Kingsmead High School</td>
+    <td class="govuk-table__cell">Kingsmead High School<br> 140467  </td>
     <td class="govuk-table__cell">{{ "2024-08-10" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -126,7 +126,7 @@
     <td class="govuk-table__cell">Amina Hassan</td>
     <td class="govuk-table__cell">Sami Hassan</td>
     <td class="govuk-table__cell">{{ "2018-11-28" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Westhaven High</td>
+    <td class="govuk-table__cell">Westhaven High<br> 140468</td>
     <td class="govuk-table__cell">{{ "2024-08-22" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -138,7 +138,7 @@
     <td class="govuk-table__cell">Jasmine Brekke</td>
     <td class="govuk-table__cell">Archie Brekke</td>
     <td class="govuk-table__cell">{{ "2021-08-06" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">St George's Primary</td>
+    <td class="govuk-table__cell">St George's Primary<br> 140469</td>
     <td class="govuk-table__cell">{{ "2024-05-05" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -150,7 +150,7 @@
     <td class="govuk-table__cell">Antonio Veum</td>
     <td class="govuk-table__cell">Layla Veum</td>
     <td class="govuk-table__cell">{{ "2021-11-06" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Parklands Junior School</td>
+    <td class="govuk-table__cell">Parklands Junior School<br> 140470</td>
     <td class="govuk-table__cell">{{ "2024-05-25" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -162,7 +162,7 @@
     <td class="govuk-table__cell">Idella Nolan</td>
     <td class="govuk-table__cell">Christina Nolan</td>
     <td class="govuk-table__cell">{{ "2020-11-28" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Southfield Primary</td>
+    <td class="govuk-table__cell">Southfield Primary<br> 140471 </td>
     <td class="govuk-table__cell">{{ "2024-05-05" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -174,7 +174,7 @@
     <td class="govuk-table__cell">Derrick Stark</td>
     <td class="govuk-table__cell">Emily Stark</td>
     <td class="govuk-table__cell">{{ "2020-07-12" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Millbridge Primary School</td>
+    <td class="govuk-table__cell">Millbridge Primary School<br> 140472</td>
     <td class="govuk-table__cell">{{ "2024-07-03" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -186,7 +186,7 @@
     <td class="govuk-table__cell">Priya Patel</td>
     <td class="govuk-table__cell">Asha Patel</td>
     <td class="govuk-table__cell">{{ "2020-02-15" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Oakwood High</td>
+    <td class="govuk-table__cell">Oakwood High<br> 140473</td>
     <td class="govuk-table__cell">{{ "2024-03-28" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -198,7 +198,7 @@
     <td class="govuk-table__cell">Michael Green</td>
     <td class="govuk-table__cell">Lucas Green</td>
     <td class="govuk-table__cell">{{ "2021-01-21" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Willow Grove Primary School</td>
+    <td class="govuk-table__cell">Willow Grove Primary School<br> 140474</td>
     <td class="govuk-table__cell">{{ "2024-07-23" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -210,7 +210,7 @@
     <td class="govuk-table__cell">Timmy Corwin-O'Conner</td>
     <td class="govuk-table__cell">Corwin-O'Conner</td>
     <td class="govuk-table__cell">{{ "2018-04-24" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Cedar Ridge Primary School</td>
+    <td class="govuk-table__cell">Cedar Ridge Primary School<br> 140475</td>
     <td class="govuk-table__cell">{{ "2024-07-17" | govukDate("truncate") }}</td>
      <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -222,7 +222,7 @@
     <td class="govuk-table__cell">David Thiel-Hayes</td>
     <td class="govuk-table__cell">Amelia Thiel-Hayes</td>
     <td class="govuk-table__cell">{{ "2019-02-26" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Meadowpark Primary School</td>
+    <td class="govuk-table__cell">Meadowpark Primary School<br> 140476</td>
     <td class="govuk-table__cell">{{ "2024-07-26" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -234,7 +234,7 @@
     <td class="govuk-table__cell">Sophie Smith</td>
     <td class="govuk-table__cell">Olivia Smith</td>
     <td class="govuk-table__cell">{{ "2019-03-03" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Brookside Primary School</td>
+    <td class="govuk-table__cell">Brookside Primary School<br> 140477</td>
     <td class="govuk-table__cell">{{ "2024-06-27" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -246,7 +246,7 @@
     <td class="govuk-table__cell">Randall Stamm-Feest</td>
     <td class="govuk-table__cell">Sarah Taylor-Stamm</td>
     <td class="govuk-table__cell">{{ "2018-11-15" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Westhaven High</td>
+    <td class="govuk-table__cell">Westhaven High<br> 140478</td>
     <td class="govuk-table__cell">{{ "2024-08-10" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -258,7 +258,7 @@
     <td class="govuk-table__cell">Wilbert Gleichner</td>
     <td class="govuk-table__cell">Maisie Gleichner</td>
     <td class="govuk-table__cell">{{ "2018-12-24" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Hilltop Primary School</td>
+    <td class="govuk-table__cell">Hilltop Primary School<br> 140479</td>
     <td class="govuk-table__cell">{{ "2024-06-01" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -270,7 +270,7 @@
     <td class="govuk-table__cell">Hugh Davis</td>
     <td class="govuk-table__cell">Toby Davis</td>
     <td class="govuk-table__cell">{{ "2020-05-12" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Greenfield Primary School</td>
+    <td class="govuk-table__cell">Greenfield Primary School<br> 140480</td>
     <td class="govuk-table__cell">{{ "2024-08-12" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -282,7 +282,7 @@
     <td class="govuk-table__cell">Casey Ortiz</td>
     <td class="govuk-table__cell">Olivia Ortiz</td>
     <td class="govuk-table__cell">{{ "2019-10-19" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Elmwood Primary School</td>
+    <td class="govuk-table__cell">Elmwood Primary School<br> 140481</td>
     <td class="govuk-table__cell">{{ "2024-05-17" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -294,7 +294,7 @@
     <td class="govuk-table__cell">Steve Lesch-Robel</td>
     <td class="govuk-table__cell">Dillon Lesch-Robel</td>
     <td class="govuk-table__cell">{{ "2021-06-18" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Kingsmead High School</td>
+    <td class="govuk-table__cell">Kingsmead High School<br> 140482</td>
     <td class="govuk-table__cell">{{ "2024-06-24" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -306,7 +306,7 @@
     <td class="govuk-table__cell">Ernie Schmitt</td>
     <td class="govuk-table__cell">Nathanial Schmitt</td>
     <td class="govuk-table__cell">{{ "2020-02-20" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Parklands Junior School</td>
+    <td class="govuk-table__cell">Parklands Junior School<br> 140483  </td>
     <td class="govuk-table__cell">{{ "2024-05-06" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -318,7 +318,7 @@
     <td class="govuk-table__cell">Libbie Marquardt</td>
     <td class="govuk-table__cell">Florence Marquardt</td>
     <td class="govuk-table__cell">{{ "2020-10-22" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">St George's Primary</td>
+    <td class="govuk-table__cell">St George's Primary<br> 140484</td>
     <td class="govuk-table__cell">{{ "2024-07-19" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -330,7 +330,7 @@
     <td class="govuk-table__cell">Laverna Weber</td>
     <td class="govuk-table__cell">Hannah Weber</td>
     <td class="govuk-table__cell">{{ "2021-08-03" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Southfield Primary School</td>
+    <td class="govuk-table__cell">Southfield Primary School<br> 140485</td>
     <td class="govuk-table__cell">{{ "2024-08-17" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -342,7 +342,7 @@
     <td class="govuk-table__cell">Robyn Stamm</td>
     <td class="govuk-table__cell">Steven Stamm</td>
     <td class="govuk-table__cell">{{ "2021-05-22" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Parklands Junior School</td>
+    <td class="govuk-table__cell">Parklands Junior School<br> 140483  </td>
     <td class="govuk-table__cell">{{ "2024-05-18" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -354,7 +354,7 @@
     <td class="govuk-table__cell">Steve Herman</td>
     <td class="govuk-table__cell">Paul Herman</td>
     <td class="govuk-table__cell">{{ "2019-09-04" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Oakwood High</td>
+    <td class="govuk-table__cell">Oakwood High<br> 140459</td>
     <td class="govuk-table__cell">{{ "2024-07-07" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -366,7 +366,7 @@
     <td class="govuk-table__cell">Charles Rothbury</td>
     <td class="govuk-table__cell">Lydia Rothbury</td>
     <td class="govuk-table__cell">{{ "2018-01-12" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Parklands Junior School</td>
+    <td class="govuk-table__cell">Parklands Junior School<br> 140483  </td>
     <td class="govuk-table__cell">{{ "2024-07-31" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 
@@ -378,7 +378,7 @@
     <td class="govuk-table__cell">Bonnie Kuhic</td>
     <td class="govuk-table__cell">Frankie Kuhic</td>
     <td class="govuk-table__cell">{{ "2018-12-02" | govukDate("truncate") }}</td>
-    <td class="govuk-table__cell">Hilltop Primary School</td>
+    <td class="govuk-table__cell">Hilltop Primary School<br> 140486 </td>
     <td class="govuk-table__cell">{{ "2024-07-09" | govukDate("truncate") }}</td>
         <td class="govuk-table__cell">{{ "2027-08-31" | govukDate("truncate") }}</td>
 


### PR DESCRIPTION
Append school codes to the school name cells in la-table-rows.html (added a <br> and URN-like numbers) to display school identifiers inline for clarity. Also simplify the eligibility tag text from "Not eligible after review" to "Not eligible". In pending_44455453.html the hardcoded end date was commented out to remove a misleading placeholder date.