### PR TITLE
Update templates: batch checks, archive & consent

### DIFF
--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/batch-checking/june-launch/batch-confirm-eligible.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/batch-checking/june-launch/batch-confirm-eligible.html
@@ -52,6 +52,7 @@ href: "javascript:window.history.back()"
           <th scope="col" class="govuk-table__header">Eligible expanded</th>
           <th scope="col" class="govuk-table__header">Not eligible</th>
           <th scope="col" class="govuk-table__header">Could not check</th>
+           <th scope="col" class="govuk-table__header">System error</th>
           <th scope="col" class="govuk-table__header">Results summary</th>
           <th scope="col" class="govuk-table__header">End date</th>
           <th scope="col" class="govuk-table__header">  </th>

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/batch-checking/june-launch/batchcheck-summary.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/batch-checking/june-launch/batchcheck-summary.html
@@ -28,7 +28,7 @@ Details need to go in here  </div>
 </details> -->
 
     <!-- <p><a href="/batch-checking/history/result-explainer"></a></p> -->
-   <p class="govuk-body">Checks confirm child eligibility for the academic year {{ academicYear }}. This summary shows a record of all check completed by your local authority. </p>
+   <p class="govuk-body">Checks confirm child eligibility for the academic year {{ academicYear }}.
 
     <table class="govuk-table govuk-table--small-text-until-tablet">
       <!-- <caption class="govuk-table__caption govuk-table__caption govuk-!-margin-bottom-4"> </caption> -->
@@ -36,10 +36,11 @@ Details need to go in here  </div>
         <tr class="govuk-table__row">
           <!-- <th scope="col" class="govuk-table__header">Academic year</th> -->
           <!-- <th scope="col" class="govuk-table__header">Submitted date</th> -->
-          <th scope="col" class="govuk-table__header">Eligible targeted</th>
-          <th scope="col" class="govuk-table__header">Eligible expanded</th>
-          <th scope="col" class="govuk-table__header">Not eligible</th>
-          <th scope="col" class="govuk-table__header">Could not check</th>
+          <th scope="col" class="govuk-table__header">Eligible<br> targeted</th>
+          <th scope="col" class="govuk-table__header">Eligible <br> expanded</th>
+          <th scope="col" class="govuk-table__header">Not eligible <br> at time of check</th>
+          <th scope="col" class="govuk-table__header">Information <br>does not match</th>
+            <th scope="col" class="govuk-table__header">System error <br> try again</th>
           <th scope="col" class="govuk-table__header">Results summary</th>
           <th scope="col" class="govuk-table__header">End date</th>
           <th scope="col" class="govuk-table__header">  </th>
@@ -58,6 +59,8 @@ Details need to go in here  </div>
           <td class="govuk-table__cell">141</td>
           <td class="govuk-table__cell">123</td>
           <td class="govuk-table__cell">47 </td>
+                    <td class="govuk-table__cell">3 </td>
+
           <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow">Checks completed</strong></td>
           <td class="govuk-table__cell">{{ "2027-08-31" | govukDate }}</td>
           <!-- <td class="govuk-table__cell"><a href="submitted-completed-applications.html">Create applications</a>

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/batch-checking/manual-no-ctf.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/batch-checking/manual-no-ctf.html
@@ -48,6 +48,8 @@
             <li>National Insurance number</li>
             <li>Childs name</li>
             <li>Childs date of birth (format DD/MM/YYYY or YYYY-MM-DD)</li>
+                        <li>School the child attends on a full time basis</li>
+
             <li>School the child attends on a full time basis</li>
           </ul>
         </li>

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/records/archived/archive-44455453.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/records/archived/archive-44455453.html
@@ -1,0 +1,45 @@
+{% extends "layouts/FSM/v8-1/layout-dfe-lanav.html" %}
+{% set childName = "Emily Johnson" %}
+{% set pageName = "Archive this record?" %}
+{% set pageName=" Archive record for " ~ childName ~ ""%}
+{% block content %}
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{pageName}}?</h1>
+    </div>
+  </div>
+
+  <div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+      <span class="govuk-visually-hidden">Warning</span>
+      Your organisation will no longer be able to edit this record if you archive it.
+    </strong>
+  </div>
+  <div class="govuk-!-padding-bottom-3"></div>
+
+
+  {{ govukButton({
+  text: "Archive now",
+  href: 'archived/archive-confirmed-44455453'
+  }) }}
+
+
+  {{ govukButton({
+  text: "Cancel archive",
+  classes: "govuk-button--secondary",
+  href: 'pending_johnson1'
+  }) }}
+
+  <div class="govuk-!-padding-bottom-3"></div>
+
+</div>
+</div>
+
+{% endblock %}
+
+{% block pageScripts %}
+<!-- <script type="text/javascript" src="/public/javascripts/moj/all.js"></script> -->
+{% endblock %}

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/records/archived/archive-confirmed-44455453.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/records/archived/archive-confirmed-44455453.html
@@ -1,4 +1,4 @@
-{% extends "layouts/FSM/v8-1/layout-dfe-lanav.html" %}
+{% extends "layouts/FSM/v8-0/layout-dfe-lanav.html" %}
 {%set childName = "Emily Johnson" %}
 {% set Date = "22 Sep 2025" %}
 {% set pageName = "Archive this record?" %}

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/records/archived/restore_44455453.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/records/archived/restore_44455453.html
@@ -1,4 +1,4 @@
-{% extends "layouts/FSM/v8-1/layout-dfe-lanav.html" %}
+{% extends "layouts/FSM/v8-0/layout-dfe-lanav.html" %}
 {% set childName = "Emily Johnson" %}
 {% set pageName = "Restore this record?" %}
 {% set pageName=" Restore record for " ~ childName ~ ""%}

--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/review/applications.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/decision/review/applications.html
@@ -1,4 +1,4 @@
-{% extends "layouts/FSM/v8-1/layout-dfe-schoolnav.html" %}
+{% extends "layouts/FSM/v8-1/layout-dfe-lanav.html" %}
 {% set applications = 29 %}
 {% set pageName = "Review " ~ applications ~ " applications" %}
 

--- a/app/views/FSM/Private_beta/v8-1/school/school-manage/decision/archive/archive-confirmed-johnson1.html
+++ b/app/views/FSM/Private_beta/v8-1/school/school-manage/decision/archive/archive-confirmed-johnson1.html
@@ -1,4 +1,4 @@
-{% extends "layouts/FSM/v7-4/layout-dfe-schoolnav-noback.html" %}
+{% extends "layouts/FSM/v8-1/layout-dfe-schoolnav.html" %}
 {%set childName = "Emily Johnson" %}
 {% set Date = "22 Sep 2025" %}
 {% set pageName = "Archive this record?" %}

--- a/app/views/FSM/Private_beta/v8-1/school/school-manage/decision/archive/view_44455453.html
+++ b/app/views/FSM/Private_beta/v8-1/school/school-manage/decision/archive/view_44455453.html
@@ -1,4 +1,4 @@
-{% extends "layouts/FSM/v8-0/layout-dfe-lanav.html" %}
+{% extends "layouts/FSM/v8-1/layout-dfe-schoolnav.html" %}
 
 {% set childId = "44455453" %}
 {% set childDOB = "22 Sep 2012" %}

--- a/app/views/FSM/Private_beta/v8-1/school/school-manage/school-soft-check/declaration-error.html
+++ b/app/views/FSM/Private_beta/v8-1/school/school-manage/school-soft-check/declaration-error.html
@@ -12,7 +12,7 @@
         <div class="govuk-error-summary__body">
           <ul class="govuk-list govuk-error-summary__list">
             <li>
-              <a href="#consent-error">Select if the parent or guardian is with you and has given consent</a>
+              <a href="#consent-error">Select if the parent or guardian has given consent. </a>
             </li></li>
           </ul>
         </div>
@@ -24,7 +24,7 @@
       <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
       <strong class="govuk-warning-text__text">
         <span class="govuk-visually-hidden">Warning</span>
-        The parent or guardian must be with you and consent for you to apply on their behalf
+        The parent or guardian must have consent for you to apply on their behalf.
       </strong>
     </div>
 
@@ -37,17 +37,17 @@
           </h2>
         </legend>
         <div id="consent-hint" class="govuk-hint">
-          Select if the parent or guardian is with you and has given consent
+          Select if the parent or guardian has given consent
         </div>
         <p id="consent-error" class="govuk-error-message">
-          <span class="govuk-visually-hidden">Error:</span> Select if the parent or guardian is with you and has given consent
+          <span class="govuk-visually-hidden">Error:</span> Select if the parent or guardian has given their consent before continuing
         </p>
         <div class="govuk-checkboxes" data-module="govuk-checkboxes">
           <div class="govuk-checkboxes__item">
             <input class="govuk-checkboxes__input" id="nationality" name="nationality" type="checkbox" value="british"
               aria-describedby="nationality-item-hint">
             <label class="govuk-label govuk-checkboxes__label" for="nationality">
-              They are with me and have given consent
+              They have given consent
             </label>
           </div>
         </div>


### PR DESCRIPTION
Add a "System error" column and count to LA batch-checking views and adjust table headers/wording for clarity. Add school field hint to manual-no-ctf. Add new archived record views (LA archive page and school archive view) and update several archived templates to use the appropriate layout variants. Change review/applications to use LA layout and update school archive-confirmed to the v8-1 school layout. Improve copy in declaration-error to clarify consent wording.