### PR TITLE
Split child name into first and last

### DIFF
--- a/app/views/FSM/Private_beta/v8-1/LA/la-manage/batch-checking/june-launch/manual-no-ctf.html
+++ b/app/views/FSM/Private_beta/v8-1/LA/la-manage/batch-checking/june-launch/manual-no-ctf.html
@@ -42,13 +42,14 @@
           the application. Add a row for each child.</li>
         <li>Make sure you include:
           <ul class="govuk-list govuk-list--bullet">
-            <li>parent first name</li>
+               <li>parent first name</li>
             <li>parent last name</li>
             <li>parent date of birth (format DD/MM/YYYY or YYYY-MM-DD)</li>
             <li>parent National Insurance number</li>
-            <li>child name</li>
+            <li>child first name</li>
+            <li>child last name</li>
             <li>child date of birth (format DD/MM/YYYY or YYYY-MM-DD)</li>
-            <li>name of the school the child attends on a full-time basis</li>
+            <!-- <li>name of the school the child attends on a full-time basis</li> -->
             <li>URN of the school the child attends on a full-time basis</li>
           </ul>
         </li>

--- a/app/views/FSM/Private_beta/v8-1/school/school-manage/batch-checking/june-launch/manual.html
+++ b/app/views/FSM/Private_beta/v8-1/school/school-manage/batch-checking/june-launch/manual.html
@@ -46,10 +46,11 @@
             <li>parent last name</li>
             <li>parent date of birth (format DD/MM/YYYY or YYYY-MM-DD)</li>
             <li>parent National Insurance number</li>
-            <li>child name</li>
+            <li>child first name</li>
+            <li>child last name</li>
             <li>child date of birth (format DD/MM/YYYY or YYYY-MM-DD)</li>
-            <li>name of the school the child attends on a full-time basis</li>
-            <li>URN of the school the child attends on a full-time basis</li>
+            <!-- <li>name of the school the child attends on a full-time basis</li> -->
+            <!-- <li>URN of the school the child attends on a full-time basis</li> -->
           </ul>
         </li>
         <li> Save it as a CSV file.</li>


### PR DESCRIPTION
Update batch-checking manual pages (LA and school) to request child first name and child last name as separate items instead of a single "child name" entry. The guidance line for the school name was commented out and the URN requirement is kept. Also includes a minor whitespace adjustment to the parent first name list item. These changes clarify the required columns for manual uploads.