### PR TITLE
Update appeal & school check templates and copy

### DIFF
--- a/app/views/FSM/Private_beta/v8-1/school/school-manage/appeal/appeal-check-answers-email.html
+++ b/app/views/FSM/Private_beta/v8-1/school/school-manage/appeal/appeal-check-answers-email.html
@@ -14,201 +14,185 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-l"></span>
+
     <h1 class="govuk-heading-l">Check your answers</h1>
 
     <div class="govuk-summary-card">
       <div class="govuk-summary-card__title-wrapper">
         <h2 class="govuk-summary-card__title">Parent or guardian details</h2>
         <ul class="govuk-summary-card__actions">
-          <li class="govuk-summary-card__action">
-            <a class="govuk-link" href="../school-soft-check/checker.html"
-              >Change<span class="govuk-visually-hidden">Parent or guardian details</span></a>
-          </li>
+          <!-- <li class="govuk-summary-card__action">
+            <a class="govuk-link" href="#">
+              Change email address<span class="govuk-visually-hidden"> parent or guardian email</span>
+            </a>
+          </li> -->
         </ul>
       </div>
+
       <div class="govuk-summary-card__content">
         <dl class="govuk-summary-list">
+
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">Full name</dt>
             <dd class="govuk-summary-list__value">
-
-
-{% if data["parent-firstname"] %}
-  {{ data["parent-firstname"] }}
-{% else %}
-  {{ parentName }}
-{% endif %}
-
-{% if data["parent-surname"] %}
-  {{ data["parent-surname"] }}
-{% else %}
-  {{ parentName }}
-{% endif %}
-
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-             Email address
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {% if data ["email"] %}{{data.email}}
+              {% if data['parent-firstname'] %}
+                {{ data['parent-firstname'] }}
               {% else %}
-              	{{email}}
+                Irina
+              {% endif %}
+
+              {% if data['parent-surname'] %}
+                {{ data['parent-surname'] }}
+              {% else %}
+                Nolan
               {% endif %}
             </dd>
           </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Date of birth
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {% if data ["dob"] %}{{ data["dob"] }}
-              {% else %}
-              {{parentDOB}}
-              {% endif %}
 
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Email address</dt>
+            <dd class="govuk-summary-list__value">
+              {% if data['email'] %}
+                {{ data['email'] }}
+              {% else %}
+                irina.nolan@gmail.com
+              {% endif %}
             </dd>
           </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-  National Insurance number
-</dt>
-          <!-- <dt class="govuk-summary-list__key">
-            {% if data['ni-number-entered'] == 'yes' %}
-              National Insurance number
-            {% else %}
-              Asylum support <br>reference number
-            {% endif %}
-          </dt> -->
-          <dd class="govuk-summary-list__value">
-            {% if data['ni-number-entered'] == 'yes' %}
-            {% if data["ni-number"] %}
-              {{ data["ni-number"] }}
-            {% else %}
-              {{nationalInsurance}}
-            {% endif %}
 
-            {% if data["nass-number-entered"] %}
-              {{ data["nass-number-entered"] }}
-            {% else %}
-              {{nationalInsurance}}
-            {% endif %}
-          {% else %}
-            {% if data["nass-number-entered"] %}
-              {{ data["nass-number-entered"] }}
-            {% else %}
-              {{nationalInsurance}}
-            {% endif %}
-          {% endif %}
-          </dd>
-        </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Date of birth</dt>
+            <dd class="govuk-summary-list__value">
+              {% if data['dob'] %}
+                {{ data['dob'] }}
+              {% else %}
+                01 Dec 1979
+              {% endif %}
+            </dd>
+          </div>
+
         </dl>
       </div>
     </div>
 
-<!--eligibility-->
- <div class="govuk-summary-card">
-      <div class="govuk-summary-card__title-wrapper">
-        <h2 class="govuk-summary-card__title">Child 1</h2>
-        <ul class="govuk-summary-card__actions">
-          <li class="govuk-summary-card__action">
-            <a class="govuk-link" href="childs-age.html">Change<span class="govuk-visually-hidden">Child details</span></a>
-          </li>
-        </ul>
-      </div>
 
-      <div class="govuk-summary-card__content">
-        <dl class="govuk-summary-list">
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key" >Child's name</dt>
-            <dd class="govuk-summary-list__value" >
-              {% if data ["ch1-first-name"] %}{{ data["ch1-first-name"] }}
-              {% else %}
-              {{childName}}
-              {% endif %}
-              {% if data ["ch1-surname"] %}{{ data["ch1-surname"] }}
-              {% else %}
-              {{childSurname}}
-              {% endif %}
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key" style="width: 40%;">Child's date of birth</dt>
-            <dd class="govuk-summary-list__value" style="width: 40%;">
-              {% if data ["ch1-day"] %} {{ data["ch1-day"] }}
-              {% else %}
-              22
-              {% endif %}
-              {% if data ["ch1-month"] %} {{ data["ch1-month"] }}
-              {% else %}
-              Sept
-              {% endif %}
-              {% if data ["ch1-year"] %} {{ data["ch1-year"] }}
-              {% else %}
-              2021
-              {% endif %}
-            </dd>
-          </div>
-        </dl>
-      </div>
-    </div>
-    <!-- #region -->
 
     <div class="govuk-summary-card">
       <div class="govuk-summary-card__title-wrapper">
-        <h2 class="govuk-summary-card__title">Child 1</h2>
+        <h2 class="govuk-summary-card__title">Eligibility details</h2>
+      </div>
+
+      <div class="govuk-summary-card__content">
+        <dl class="govuk-summary-list">
+
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Status</dt>
+            <dd class="govuk-summary-list__value">
+              <strong class="govuk-tag {{ 'govuk-tag--yellow' }}">
+                {{ "Evidence needed" }}
+              </strong>
+            </dd>
+          </div>
+
+          <!-- <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Eligibility end date</dt>
+            <dd class="govuk-summary-list__value">
+              {{ data["endDate"] or "31 August 2027" }}
+            </dd>
+          </div> -->
+
+        </dl>
+      </div>
+    </div>
+
+
+    <div class="govuk-summary-card">
+      <div class="govuk-summary-card__title-wrapper">
+        <h2 class="govuk-summary-card__title">Child 1 details</h2>
         <ul class="govuk-summary-card__actions">
           <li class="govuk-summary-card__action">
-            <a class="govuk-link" href="childs-age.html">Change<span class="govuk-visually-hidden">Child details</span></a>
+            <a class="govuk-link" href="outcome-eligible-childs-age.html">
+              Change child details<span class="govuk-visually-hidden"> for child 1</span>
+            </a>
           </li>
         </ul>
       </div>
 
       <div class="govuk-summary-card__content">
         <dl class="govuk-summary-list">
+
           <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key" >Child's name</dt>
-            <dd class="govuk-summary-list__value" >
-              {% if data ["ch1-first-name"] %}{{ data["ch1-first-name"] }}
-              {% else %}
-              {{childName}}
-              {% endif %}
-              {% if data ["ch1-surname"] %}{{ data["ch1-surname"] }}
-              {% else %}
-              {{childSurname}}
-              {% endif %}
+            <dt class="govuk-summary-list__key">Name</dt>
+            <dd class="govuk-summary-list__value">
+              {{ data["person"][0]["first_name"] or "Christina" }}
+              {{ data["person"][0]["last_name"] or data["parent-surname"] or "Nolan" }}
             </dd>
           </div>
+
           <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key" style="width: 40%;">Child's date of birth</dt>
-            <dd class="govuk-summary-list__value" style="width: 40%;">
-              {% if data ["ch1-day"] %} {{ data["ch1-day"] }}
-              {% else %}
-              22
-              {% endif %}
-              {% if data ["ch1-month"] %} {{ data["ch1-month"] }}
-              {% else %}
-              Sept
-              {% endif %}
-              {% if data ["ch1-year"] %} {{ data["ch1-year"] }}
-              {% else %}
-              2021
-              {% endif %}
+            <dt class="govuk-summary-list__key">Date of birth</dt>
+            <dd class="govuk-summary-list__value">
+              {{ data["person"][0]["dob"]["day"] or "12" }}
+              {{ data["person"][0]["dob"]["month"] or "06" }}
+              {{ data["person"][0]["dob"]["year"] or "2020" }}
+            </dd>
+          </div>
+
+            <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">School</dt>
+            <dd class="govuk-summary-list__value">
+              {{ data["person"][0]["school"] or "St Marys primary school, HE12 4TY" }}
             </dd>
           </div>
         </dl>
       </div>
     </div>
 
-    {% if data['child-2'] == 'Yes' %} {% endif %}
 
+    <div class="govuk-summary-card">
+      <div class="govuk-summary-card__title-wrapper">
+        <h2 class="govuk-summary-card__title">Evidence</h2>
+        <ul class="govuk-summary-card__actions">
+          <li class="govuk-summary-card__action">
+            <a class="govuk-link" href="../upload/upload-evidence.html">
+              Upload evidence<span class="govuk-visually-hidden"> </span>
+            </a>
+          </li>
+        </ul>
+      </div>
 
+      <div class="govuk-summary-card__content">
+        <dl class="govuk-summary-list">
 
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">File 1</dt>
+            <dd class="govuk-summary-list__value">
+             Add evidence
+            </dd>
+          </div>
+
+          <!-- <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">File 2</dt>
+            <dd class="govuk-summary-list__value">
+              {% if data['filename-2'] %}
+                {{ data['filename-2'] }}
+              {% else %}
+                Scan0123099647.png
+              {% endif %}
+            </dd>
+          </div>
+
+        </dl>
+      </div>
+    </div>-->
+</dl>
+      </div>
+    </div>
     <h2 class="govuk-heading-m">Confirm and send application</h2>
 
-    <p class="govuk-body">By sending this information, you confirm that, to the best of your knowledge, the details are correct.</p>
+    <p class="govuk-body">
+      By sending this information, you confirm that, to the best of your knowledge, the details are correct and evidence will be provided.
+    </p>
 
 
     <form action="application-sent" method="post" novalidate>

--- a/app/views/FSM/Private_beta/v8-1/school/school-manage/appeal/appeal-check-answers-evidence.html
+++ b/app/views/FSM/Private_beta/v8-1/school/school-manage/appeal/appeal-check-answers-evidence.html
@@ -13,13 +13,13 @@
       <div class="govuk-summary-card__title-wrapper">
         <h2 class="govuk-summary-card__title">Parent or guardian details</h2>
         <ul class="govuk-summary-card__actions">
-          <li class="govuk-summary-card__action">
-            <!-- <a class="govuk-link" href="../school-soft-check/checker.html">
-              Change<span class="govuk-visually-hidden"> parent or guardian details</span>
-            </a> -->
-          </li>
+          <!-- <li class="govuk-summary-card__action">
+            <a class="govuk-link" href="#">
+              Change email address<span class="govuk-visually-hidden"> parent or guardian email</span>
+            </a>
+          </li> -->
         </ul>
-      </div>
+      </div>å
 
       <div class="govuk-summary-card__content">
         <dl class="govuk-summary-list">
@@ -30,13 +30,13 @@
               {% if data['parent-firstname'] %}
                 {{ data['parent-firstname'] }}
               {% else %}
-                Eden
+                Irina
               {% endif %}
 
               {% if data['parent-surname'] %}
                 {{ data['parent-surname'] }}
               {% else %}
-                Tesfay
+                Nolan
               {% endif %}
             </dd>
           </div>
@@ -47,7 +47,7 @@
               {% if data['email'] %}
                 {{ data['email'] }}
               {% else %}
-                eden.tesfay@gmail.com
+                irina.nolan@gmail.com
               {% endif %}
             </dd>
           </div>
@@ -58,7 +58,7 @@
               {% if data['dob'] %}
                 {{ data['dob'] }}
               {% else %}
-                06 Dec 1979
+                01 Dec 1979
               {% endif %}
             </dd>
           </div>
@@ -80,18 +80,18 @@
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">Status</dt>
             <dd class="govuk-summary-list__value">
-              <strong class="govuk-tag {{ data['tagClass'] or 'govuk-tag--purple' }}">
-                {{ data["policyLabel"] or "Eligible targeted" }}
+              <strong class="govuk-tag {{ 'govuk-tag--blue' }}">
+                {{ "Review needed" }}
               </strong>
             </dd>
           </div>
 
-          <div class="govuk-summary-list__row">
+          <!-- <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">Eligibility end date</dt>
             <dd class="govuk-summary-list__value">
               {{ data["endDate"] or "31 August 2027" }}
             </dd>
-          </div>
+          </div> -->
 
         </dl>
       </div>
@@ -104,7 +104,7 @@
         <ul class="govuk-summary-card__actions">
           <li class="govuk-summary-card__action">
             <a class="govuk-link" href="outcome-eligible-childs-age.html">
-              Edit details<span class="govuk-visually-hidden"> for child 1</span>
+              Change child details<span class="govuk-visually-hidden"> for child 1</span>
             </a>
           </li>
         </ul>
@@ -130,6 +130,12 @@
             </dd>
           </div>
 
+            <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">School</dt>
+            <dd class="govuk-summary-list__value">
+              {{ data["person"][0]["school"] or "St Marys primary school, HE12 4TY" }}
+            </dd>
+          </div>
         </dl>
       </div>
     </div>
@@ -141,7 +147,7 @@
         <ul class="govuk-summary-card__actions">
           <li class="govuk-summary-card__action">
             <a class="govuk-link" href="../upload/upload-evidence.html">
-              Change<span class="govuk-visually-hidden"> evidence</span>
+              Update evidence<span class="govuk-visually-hidden"> </span>
             </a>
           </li>
         </ul>
@@ -161,7 +167,7 @@
             </dd>
           </div>
 
-          <div class="govuk-summary-list__row">
+          <!-- <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">File 2</dt>
             <dd class="govuk-summary-list__value">
               {% if data['filename-2'] %}
@@ -170,7 +176,7 @@
                 Scan0123099647.png
               {% endif %}
             </dd>
-          </div>
+          </div> -->
 
         </dl>
       </div>

--- a/app/views/FSM/Private_beta/v8-1/school/school-manage/appeal/confirmation-appeal-with-evidence.html
+++ b/app/views/FSM/Private_beta/v8-1/school/school-manage/appeal/confirmation-appeal-with-evidence.html
@@ -56,8 +56,8 @@
           </td>
 
           <td class="govuk-table__cell">
-            <strong class="govuk-tag {{ data['tagClass'] or 'govuk-tag--purple' }}">
-              {{ data["policyLabel"] or "Eligible targeted" }}
+            <strong class="govuk-tag {{ 'govuk-tag--yellow' }}">
+              {{ "Evidence needed" }}
             </strong>
           </td>
 
@@ -89,7 +89,7 @@
           <td class="govuk-table__cell"> </th>
         </tr>
 
-        <tbody class="govuk-table__body">
+        <!-- <tbody class="govuk-table__body">
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">    Scan0123099647.png
             </td>
@@ -98,7 +98,7 @@
                       <td class="govuk-table__cell">586kb</td>
 
           </tr>
-      </tbody>
+      </tbody> -->
     </table>
 
 
@@ -109,24 +109,23 @@
         <div class="govuk-grid-column-full">
           <h2 class="govuk-heading-m">What to do next</h2>
 
-          <p class="govuk-body">All approved decisions can be found in <a class="govuk-link"
-            href="/FSM/Private_beta/v8-1/school/school-manage/decision/finalise/applications"> Finalise applications</a>.
-        </p>
+<p class="govuk-body">Review the supporting evidence before making a decision on this application.</p>
 
+          <p class="govuk-body">Read the <a href="../../guidance/guidance-steps/policy-guidance.html">guidance for reviewing evidence (opens in new tab)</a>
 
+            <p class="govuk-body">Once you have reviewed the evidence, record your decision in the <a href="">application record</a> or got to <a href="../decision/review/applications.html">Review evidence</a> to view all applications that need a decision.</p>
 
+<div class="govuk-!-padding-top-5">
+        <a class="govuk-body govuk-link" href="../checker">
+          Do another check
+        </a></div>
 
+         <!-- <div class="govuk-button-group">
 
-        </div>
-      </div>
+               <a href="../../appeal/appeal-new-child-age.html" class="govuk-button" role="button" data-module="govuk-button">
+Do another check</a></div> -->
+ </div>
     </div>
-    <!--
-<div class="govuk-!-padding-bottom-3"></div>
--->
-
-
-
-
 
   </div>
 </div>

--- a/app/views/FSM/Private_beta/v8-1/school/school-manage/school-soft-check/outcomes/school-check-result.html
+++ b/app/views/FSM/Private_beta/v8-1/school/school-manage/school-soft-check/outcomes/school-check-result.html
@@ -129,12 +129,14 @@
         }
       </script>
 
-      <div class="govuk-button-group">
-        <a href="../checker" class="govuk-button" role="button" data-module="govuk-button">
-          Do another check
-        </a>
+  <div class="govuk-button-group">
+
+               <a href="../../apply/outcome-eligible-childs-age.html" class="govuk-button" role="button" data-module="govuk-button">
+Continue to add child details</a>
+
+
         <a class="govuk-link" href="../../apply/outcome-eligible-childs-age.html">
-          Continue to add child details
+          Do another check
         </a>
       </div>
 
@@ -178,15 +180,26 @@
 
     <p>If you have not received any supporting evidence, you can still add the child details now and contact the parent or guardian for the evidence and add it later.  </p>
 
-     <div class="govuk-button-group">
+     <!-- <div class="govuk-button-group">
         <a href="../checker" class="govuk-button" role="button" data-module="govuk-button">
           Run another check
         </a>
           <a class="govuk-link" href="../../appeal/appeal-new-child-age.html">
           Continue to add child details
         </a>
-      </div>
+      </div> -->
 
+
+      <div class="govuk-button-group">
+
+               <a href="../../appeal/appeal-new-child-age.html" class="govuk-button" role="button" data-module="govuk-button">
+Continue to add child details</a>
+
+
+        <a class="govuk-link" href="../checker">
+          Do another check
+        </a>
+      </div>
 
         <p>You can <a href="" class="govuk-link" onclick="printPage()">print this page</a> for the parent or guardian to keep.</p>
 


### PR DESCRIPTION
Adjust FSM Private_beta v8-1 templates for appeal and school-check flows. Show parent/child details from data (using data.person where available) and add sample default values (e.g. Irina Nolan). Change status tags to “Evidence needed” / “Review needed”, update button/link targets and labels to point to appeal/upload/review pages, and comment out unused file-list markup. Also include minor markup and copy cleanups across: appeal-check-answers-email.html, appeal-check-answers-evidence.html, confirmation-appeal-with-evidence.html, and school-check-result.html.